### PR TITLE
Update zh_CN.lang

### DIFF
--- a/src/main/resources/assets/chiselsandbits/lang/zh_CN.lang
+++ b/src/main/resources/assets/chiselsandbits/lang/zh_CN.lang
@@ -1,5 +1,6 @@
 
 itemGroup.chiselsandbits=雕刻工艺
+itemGroup.chiselsandbits.Clipboard=雕刻工艺剪贴板
 
 tile.mod.chiselsandbits.chiseled_wood.name=雕刻木头
 tile.mod.chiselsandbits.chiseled_rock.name=雕刻石头
@@ -9,6 +10,14 @@ tile.mod.chiselsandbits.chiseled_glass.name=雕刻玻璃
 tile.mod.chiselsandbits.chiseled_ice.name=雕刻冰块
 tile.mod.chiselsandbits.chiseled_packedIce.name=雕刻蓝冰
 tile.mod.chiselsandbits.chiseled_clay.name=雕刻粘土
+tile.mod.chiselsandbits.chiseled_sand.name=雕刻沙子
+tile.mod.chiselsandbits.chiseled_ground.name=雕刻泥土
+tile.mod.chiselsandbits.chiseled_grass.name=雕刻草块
+tile.mod.chiselsandbits.chiseled_snow.name=雕刻雪块
+tile.mod.chiselsandbits.chiseled_fluid.name=雕刻流体
+tile.mod.chiselsandbits.chiseled_leaves.name=雕刻树叶
+
+tile.mod.chiselsandbits.bittank.name=流体雕刻储罐
 
 item.mod.chiselsandbits.block_bit.name=雕刻碎屑
 item.mod.chiselsandbits.bit_bag.name=雕刻碎屑袋
@@ -26,6 +35,9 @@ item.mod.chiselsandbits.chisel_iron.name=铁凿
 item.mod.chiselsandbits.chisel_gold.name=金凿
 item.mod.chiselsandbits.chisel_diamond.name=钻石凿
 
+item.mod.chiselsandbits.bitsaw_diamond.name=钻石碎屑锯
+item.mod.chiselsandbits.tape_measure.name=卷尺
+
 mod.chiselsandbits.chiselmode.single=丁状
 mod.chiselsandbits.chiselmode.snap2=捕获1/8网格大小的方块
 mod.chiselsandbits.chiselmode.snap4=捕获1/4网格大小的方块
@@ -38,50 +50,134 @@ mod.chiselsandbits.chiselmode.cube_medium=中等块
 mod.chiselsandbits.chiselmode.cube_large=大块
 mod.chiselsandbits.chiselmode.drawn_region=绘制区域
 
+mod.chiselsandbits.positivepatternmode.replace=完全替换
+mod.chiselsandbits.positivepatternmode.additive=附加
+mod.chiselsandbits.positivepatternmode.placement=放置
+mod.chiselsandbits.positivepatternmode.impose=部分替换
+
+mod.chiselsandbits.tapemeasure.chatmsg=x: %s,  y: %s,  z: %s
+mod.chiselsandbits.tapemeasure.bit=碎屑
+mod.chiselsandbits.tapemeasure.block=方块
+mod.chiselsandbits.tapemeasure.distance=直线
+
+mod.chiselsandbits.result.out_of_range=距离过远
+mod.chiselsandbits.result.has_changed=方块已被改变
+mod.chiselsandbits.result.missing_bits=碎屑不够或凿的耐久过低!
+mod.chiselsandbits.result.nothing_to_undo=未找到可撤销的内容
+mod.chiselsandbits.result.nothing_to_redo=未找到可恢复的内容
+
 mod.chiselsandbits.other.rotate.ccw=逆时针旋转所持方块
 mod.chiselsandbits.other.rotate.cw=顺时针旋转所持方块
 mod.chiselsandbits.other.mode=打开径向菜单
+mod.chiselsandbits.other.undo=撤销
+mod.chiselsandbits.other.redo=恢复
+mod.chiselsandbits.other.pickbit=获取碎屑
+mod.chiselsandbits.other.add_to_clipboard=保存方块至剪贴板
 
 mod.chiselsandbits.help.shiftdetails=<按住shift以查看更多>
 mod.chiselsandbits.help.empty=空
-mod.chiselsandbits.help.solid=固体
+mod.chiselsandbits.help.filled=非空
 
 mod.chiselsandbits.help.chiseled_block=左击以放置雕塑;潜行时会忽略方块网格;鼠标滚轮可以循环改变放置朝向.
 mod.chiselsandbits.help.bit_bag=自动存放和补充雕刻碎屑.
 mod.chiselsandbits.help.wrench=右击以旋转方块.
-mod.chiselsandbits.help.bit=左击以进行雕刻;右击可以放置;使用{}键来打开菜单.
-mod.chiselsandbits.help.positiveprint=右击以写入图纸;之后右击可以直接雕刻或放置雕塑,;也可以同碎屑或碎屑袋一起进行合成.;鼠标滚轮可以循环改变放置朝向.
+mod.chiselsandbits.help.bit=左击以进行雕刻;右击可以放置;使用{}键打开菜单.
+mod.chiselsandbits.help.positiveprint=右击以写入图纸;之后右击可以直接雕刻或放置雕塑,;也可以同碎屑或碎屑袋一起进行合成.;鼠标滚轮可以循环改变放置朝向.;使用{}键打开菜单.
 mod.chiselsandbits.help.negativeprint=右击以写入图纸;之后右击可以直接雕刻或放置雕塑.;鼠标滚轮可以循环改变放置朝向.
 mod.chiselsandbits.help.mirrorprint=右击想要镜像的雕塑方块以写入图纸;和正型/负型雕塑图纸一起合成来传递图案.
-mod.chiselsandbits.help.chisel=左击以进行雕刻;右击可以循环改变模式;使用{}键来打开菜单.
+mod.chiselsandbits.help.chisel=左击以进行雕刻;使用{}键打开菜单.
+mod.chiselsandbits.help.bitsaw=和方块或雕塑进行合成;可沿三个轴的任一方向切开.
+mod.chiselsandbits.help.bittank=装入流体,提取碎屑.
+mod.chiselsandbits.help.tape_measure=按住右键并拖拽以测量;潜行+右键可清除之前的测绘;使用{}键打开菜单.
 
 mod.chiselsandbits.help.chiseled_block.long=左击以放置雕塑;潜行时会忽略方块网格.Shift+鼠标滚轮可以循环改变放置朝向.
-mod.chiselsandbits.help.bit_bag.long=自动存放和补充雕刻碎屑:物品栏内多余一组的部分将被存储,少于一组的部分将被自动补充到一组.
+mod.chiselsandbits.help.bit_bag.long=自动存放和补充雕刻碎屑:物品栏内碎屑多余一组的部分将被存储,少于一组的部分将被自动补充到一组.
 mod.chiselsandbits.help.wrench.long=右击方块时将会以你右击的面为轴旋转该方块.
+mod.chiselsandbits.help.tape_measure.long=按住右键并拖拽以测量空间. 潜行使用可以清除之前所有创建的绘制. 在菜单中可以切换不同的测绘模式.
 mod.chiselsandbits.help.bit.long=左击以雕刻方块中标示的区域.右击以在目标区域放置.
-mod.chiselsandbits.help.positiveprint.long=右击一个雕塑方块以写入图纸.之后右击方块时将会按照图纸添加碎屑并移除不匹配图纸的部分.你也可以在工作台中将图纸和碎屑或碎屑袋一起合成.使用Shift+鼠标滚轮可以无移动循环旋转其朝向.
+mod.chiselsandbits.help.positiveprint.long=右击一个雕塑方块以写入图纸.之后右击方块时将会按照图纸添加碎屑并移除不匹配图纸的部分.你也可以在工作台中将图纸和碎屑或碎屑袋一起合成.使用Shift+鼠标滚轮可以无移动地循环旋转其朝向.
 mod.chiselsandbits.help.negativeprint.long=右击一个雕塑方块以写入图纸.之后右击方块时将会移除方块不在负型图纸中的部分.使用Shift+鼠标滚轮可以无移动地循环旋转其朝向.
 mod.chiselsandbits.help.mirrorprint.long=右击你想要镜像的雕塑方块以写入图纸,如果右击的是东面,则会沿着东->西轴镜像该图案.和正型/负型雕塑图纸一起合成以传递镜像后的图案到你所选择的图纸上.
 mod.chiselsandbits.help.chisel.long=左击任何兼容的方块来雕刻.右击可以循环改变雕刻模式,你也可以使用Shift+鼠标滚轮来循环改变模式.
+mod.chiselsandbits.help.bitsaw.long=将这把锯子和其所支持的方块或对称的雕塑一起合成,可以将它们切成两半. 合成中锯子和方块的位置关系决定了将会沿哪个轴切开,锯子放在方块左右两侧将会沿X轴切开方块,放在上下两侧则会沿Y轴切开,放在对角两侧则会沿Z轴切开.
+mod.chiselsandbits.help.bittank.long=用桶右击它可以加入或从中移除液体. 不持有桶的时候右击将会从装入液体的储罐中提取碎屑,Shift+右键将会向其填入玩家手上的碎屑,空手这样填入时将会填入尽可能多的碎屑. 你可以使用漏斗之类的物品从装有液体的储罐中自动提取碎屑.
 
 mod.chiselsandbits.help.leftalt=左Alt
 mod.chiselsandbits.help.rightalt=右Alt
+mod.chiselsandbits.help.trash=删除袋中碎屑,可将物品拖过来过滤.
+mod.chiselsandbits.help.trashitem=仅删除%s
+mod.chiselsandbits.help.reallytrash=再次点击以确认清空袋中所有碎屑
+mod.chiselsandbits.help.reallytrash_blank=再次点击以确认删除所有%s
+mod.chiselsandbits.help.trash.invalid=无法删除%s
 
+mod.chiselsandbits.pretty.axis-y=上/下
+mod.chiselsandbits.pretty.axis-x=东/西
+mod.chiselsandbits.pretty.axis-z=北/南
+
+mod.chiselsandbits.pretty.facing-up=上
+mod.chiselsandbits.pretty.facing-down=下
+mod.chiselsandbits.pretty.facing-east=东
+mod.chiselsandbits.pretty.facing-west=西
+mod.chiselsandbits.pretty.facing-north=北
+mod.chiselsandbits.pretty.facing-south=南
+
+chiselsandbits.color.white=白色
+chiselsandbits.color.orange=橙色
+chiselsandbits.color.magenta=品红色
+chiselsandbits.color.lightBlue=淡蓝色
+chiselsandbits.color.yellow=黄色
+chiselsandbits.color.lime=黄绿色
+chiselsandbits.color.pink=粉红色
+chiselsandbits.color.gray=灰色
+chiselsandbits.color.silver=淡灰色
+chiselsandbits.color.cyan=青色
+chiselsandbits.color.purple=紫色
+chiselsandbits.color.blue=蓝色
+chiselsandbits.color.brown=棕色
+chiselsandbits.color.green=绿色
+chiselsandbits.color.red=红色
+chiselsandbits.color.black=黑色
+
+commands.setbit.usage=/setbit <x> <y> <z> <bitx> <bity> <bitz> <TileName> [dataValue]
+commands.setbit.outOfWorld=无法在世界外放置方块
+commands.setbit.noChange=碎屑无法被放置
+commands.setbit.success=已成功放置碎屑
+commands.setbit.cannotChiselBlock=方块无法被雕刻
+commands.setbit.invalidState=非法碎屑类型
+commands.setbit.spaceOccupied=空间已被占据,无法放置碎屑
+
+mod.chiselsandbits.config.maxUndoLevel=最大撤销次数
+mod.chiselsandbits.config.persistCreativeClipboard=保存/读取创造剪贴板内容
+mod.chiselsandbits.config.fluidBitsAreClickThough=左击时穿透流体碎屑
+mod.chiselsandbits.config.addBrokenBlocksToCreativeClipboard=破坏雕塑时自动保存至创造剪贴板
+mod.chiselsandbits.config.creativeClipboardSize=创造剪贴板的容量
+mod.chiselsandbits.config.creativeClipboardSize.tooltip=创造剪贴板存放物品的最大数量,超过该值后之前存放的内容将被覆盖,设置为0将会禁用剪贴板.
 mod.chiselsandbits.config.ShowBitsInJEI=在JEI中显示雕刻碎屑
+mod.chiselsandbits.config.maxDrawnRegionSize=绘制区域的大小
 mod.chiselsandbits.config.showUsage=为物品描述添加提示性文字
 mod.chiselsandbits.config.invertBitBagFullness=反相碎屑袋的耐久条
 mod.chiselsandbits.config.enableChiselMode_Plane=启用模式 - 板状
 mod.chiselsandbits.config.enableChiselMode_ConnectedPlane=启用模式 - 连接板状
 mod.chiselsandbits.config.enableChiselMode_Line=启用模式 - 条状
 mod.chiselsandbits.config.enableChiselMode_SmallCube=启用模式 - 小块
-mod.chiselsandbits.config.enableChiselMode_LargeCube=启用模式 - 中等块
-mod.chiselsandbits.config.enableChiselMode_HugeCube=启用模式 - 大块
+mod.chiselsandbits.config.enableChiselMode_LargeCube=启用模式 - 大块
+mod.chiselsandbits.config.enableChiselMode_MediumCube=启用模式 - 中等块
 mod.chiselsandbits.config.enableChiselMode_DrawnRegion=启用模式 - 绘制区域
 mod.chiselsandbits.config.enableChiselMode_Snap2=启用模式 - 捕获1/8网格大小的方块
 mod.chiselsandbits.config.enableChiselMode_Snap4=启用模式 - 捕获1/4网格大小的方块
 mod.chiselsandbits.config.enableChiselMode_Snap8=启用模式 - 捕获1/2网格大小的方块
+
+mod.chiselsandbits.config.enablePositivePatternMode_Additive=启用模式 - 附加
+mod.chiselsandbits.config.enablePositivePatternMode_Impose=启用模式 - 部分替换
+mod.chiselsandbits.config.enablePositivePatternMode_Placement=启用模式 - 放置
+mod.chiselsandbits.config.enablePositivePatternMode_Replace=启用模式 - 完全替换
+
+mod.chiselsandbits.config.enableTapeMeasure_Bit=启用模式 - 碎屑
+mod.chiselsandbits.config.enableTapeMeasure_Block=启用模式 - 方块
+mod.chiselsandbits.config.enableTapeMeasure_Distance=启用模式 - 直线
+
 mod.chiselsandbits.config.enableToolbarIcons=在工具栏中显示模式图标
-mod.chiselsandbits.config.perChiselMode=每个工具存储所选择的模式
+mod.chiselsandbits.config.perChiselMode=存储每个凿所选择的模式
 mod.chiselsandbits.config.chatModeNotification=用聊天信息提示模式改变
 mod.chiselsandbits.config.itemNameModeDisplay=用工具栏上方高亮信息提示模式改变
 mod.chiselsandbits.config.dynamicModelFaceCount=静态渲染的最大面数
@@ -99,24 +195,24 @@ mod.chiselsandbits.config.enableStackableCrafting=通过合成清除雕塑方块
 mod.chiselsandbits.config.enableStackableCrafting.tooltip=你可以利用这个特性移除掉旋转从而堆叠相同样式的方块
 mod.chiselsandbits.config.enableNegativePrintInversionCrafting=反相负型雕塑图纸
 mod.chiselsandbits.config.enableNegativePrintInversionCrafting.tooltip=通过将已写入的雕塑图纸和空白图纸一起合成
-mod.chiselsandbits.config.enableBitBag=启用雕塑碎屑袋
+mod.chiselsandbits.config.enableBitBag=启用雕刻碎屑袋
 mod.chiselsandbits.config.enableNegativePrint=启用负型雕塑图纸
 mod.chiselsandbits.config.enablePositivePrint=启用正型雕塑图纸
 mod.chiselsandbits.config.enableMirrorPrint=启用镜像雕塑图纸
-mod.chiselsandbits.config.enableChisledBits=启用雕塑碎屑
+mod.chiselsandbits.config.enableChisledBits=启用雕刻碎屑
 mod.chiselsandbits.config.enableStoneChisel=启用石凿
 mod.chiselsandbits.config.enableIronChisel=启用铁凿
 mod.chiselsandbits.config.enableGoldChisel=启用金凿
 mod.chiselsandbits.config.enableDiamondChisel=启用钻石凿
 mod.chiselsandbits.config.enableWoodenWrench=启用木头扳手
 mod.chiselsandbits.config.enableChiselToolHarvestCheck=检查工具种类或凿子的等级
-mod.chiselsandbits.config.enableChiselToolHarvestCheck.tooltip=你必须用钻石凿才能获得黑曜石雕塑碎屑
+mod.chiselsandbits.config.enableChiselToolHarvestCheck.tooltip=你必须用钻石凿才能获得黑曜石雕刻碎屑
 mod.chiselsandbits.config.enableChiselToolHarvestCheckTools=被凿子模拟的工具种类
-mod.chiselsandbits.config.enableToolHarvestLevels=当打碎方块时检查工具等级
-mod.chiselsandbits.config.enableToolHarvestLevels.tooltip=打碎一个原始的黑曜石雕塑方块时需要钻石等级的工具.
+mod.chiselsandbits.config.enableToolHarvestLevels=当破坏方块时检查工具等级
+mod.chiselsandbits.config.enableToolHarvestLevels.tooltip=破坏黑曜石雕塑方块时需要钻石等级的工具.
 mod.chiselsandbits.config.enableBitLightSource=雕塑方块可以发光
 mod.chiselsandbits.config.enableBitLightSource.tooltip=禁用发光设定后,碎屑将仅仅只会荧光而方块将不会提供任何亮度等级
-mod.chiselsandbits.config.bitLightPercentage=方块发出最大亮度的碎屑百分比
+mod.chiselsandbits.config.bitLightPercentage=方块发出最大亮度时碎屑所占百分比
 mod.chiselsandbits.config.compatabilityMode=提升模组兼容性
 mod.chiselsandbits.config.enableAPITestingItem=启用API测试物品
 mod.chiselsandbits.config.bagStackSize=碎屑袋 - 碎屑堆叠大小
@@ -126,3 +222,9 @@ mod.chiselsandbits.config.ironChiselUses=铁凿耐久度
 mod.chiselsandbits.config.diamondChiselUses=钻石凿耐久度
 mod.chiselsandbits.config.goldChiselUses=金凿耐久度
 mod.chiselsandbits.config.wrenchUses=扳手耐久度
+mod.chiselsandbits.config.enableRightClickModeChange=右击时循环切换凿的模式
+mod.chiselsandbits.config.enableSetBitCommand=启用/setbit指令
+mod.chiselsandbits.config.maxMillisecondsPerBlock=每个方块的最大毫秒数
+mod.chiselsandbits.config.maxMillisecondsUploadingPerFrame=上传/循环的最大毫秒数
+mod.chiselsandbits.config.maxTapeMeasures=卷尺最大同时存在的测绘数量
+mod.chiselsandbits.config.displayMeasuringTapeInChat=在聊天栏中显示卷尺的测量信息


### PR DESCRIPTION
Update zh_CN.lang to chiselsandbits-11.7.

I finished all the updates. However, I was confused by a tooltip while doing the translation.
Just as [what the code shows](https://github.com/AlgorithmX2/Chisels-and-Bits/blob/1.10/src/main/java/mod/chiselsandbits/items/ItemNegativePrint.java#L85-L93), the tooptip of the negative chisel design displays "Empty" after the soild bit number and displays "Filled" after the air number. I assume these two localization strings should be swapped with each other because of negative design's function.
Should they be exchanged? Or do I just misunderstand something?
