### PR TITLE
Use https to avoid mixed content warnings

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,2 +1,2 @@
 markdown: kramdown
-root: http://algorithmx2.github.io/Chisels-and-Bits
+root: https://algorithmx2.github.io/Chisels-and-Bits


### PR DESCRIPTION
This fixes the broken styling in Chrome when accessing the site over https, which otherwise works great.

![screenshot 2016-10-07 kl 23 46 04](https://cloud.githubusercontent.com/assets/664779/19206322/4a9a564e-8ce8-11e6-96c8-ea48339294c9.png)
