### PR TITLE
Allowed key binding annotation IMC to work with uppercase mod IDs.

### DIFF
--- a/src/main/java/mod/chiselsandbits/core/api/IMCHandlerKeyBindingAnnotations.java
+++ b/src/main/java/mod/chiselsandbits/core/api/IMCHandlerKeyBindingAnnotations.java
@@ -30,7 +30,7 @@ public class IMCHandlerKeyBindingAnnotations implements IMCMessageHandler
 			{
 				regName = item.getRegistryName();
 
-				if ( regName == null || !regName.getResourceDomain().equals( message.getSender() ) )
+				if ( regName == null || !regName.getResourceDomain().equals( message.getSender().toLowerCase() ) )
 				{
 					continue;
 				}


### PR DESCRIPTION
Prior to 1.11, mod IDs must be set to lowercase when comparing with resource location domains.

Although it probably never should have been, EBM's mod ID is camel case. Since I can't release for 1.10.2 until this is fixed, can you make another 1.10.2 release?