### PR TITLE
Fix reading the cross-world format - it didn't convert the primary state

### DIFF
--- a/src/main/java/mod/chiselsandbits/chiseledblock/NBTBlobConverter.java
+++ b/src/main/java/mod/chiselsandbits/chiseledblock/NBTBlobConverter.java
@@ -189,6 +189,13 @@ public class NBTBlobConverter
 			formatChanged = true;
 			v = voxelBlobRef.getVoxelBlob().blobToBytes( preferedFormat );
 			voxelBlobRef = new VoxelBlobStateReference( v, 0 );
+
+			// When reading from the cross-world format, the primary state needs to also be converted.
+			if ( format == VoxelBlob.VERSION_CROSSWORLD )
+			{
+				primaryBlockState = voxelBlobRef.getVoxelBlob().getVoxelStats().mostCommonState;
+			}
+
 			format = voxelBlobRef.getFormat();
 		}
 


### PR DESCRIPTION
I don't know if this is the correct/best way to get the new primary state, but it seems to at least fix the cross-world format functionality.

* Without the fix: http://i.imgur.com/CNCCzAJ.png
* With the fix: http://i.imgur.com/IXAUeTX.png