### PR TITLE
Add Vivecraft compatibility

### DIFF
--- a/src/main/java/mod/chiselsandbits/client/gui/ChiselsAndBitsMenu.java
+++ b/src/main/java/mod/chiselsandbits/client/gui/ChiselsAndBitsMenu.java
@@ -1,5 +1,6 @@
 package mod.chiselsandbits.client.gui;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.concurrent.TimeUnit;
 
@@ -14,12 +15,14 @@ import mod.chiselsandbits.helpers.DeprecationHelper;
 import mod.chiselsandbits.helpers.LocalStrings;
 import mod.chiselsandbits.modes.IToolMode;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiButton;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.client.renderer.VertexBuffer;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
+import net.minecraft.inventory.ClickType;
 import net.minecraft.item.EnumDyeColor;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.EnumHand;
@@ -454,4 +457,23 @@ public class ChiselsAndBitsMenu extends GuiScreen
 	{
 		return n > 0 ? 1 : -1;
 	}
+
+    /**
+     * Called when the mouse is clicked. Args : mouseX, mouseY, clickedButton
+     */
+    protected void mouseClicked(
+    		int mouseX,
+    		int mouseY,
+    		int mouseButton ) throws IOException
+    {
+        if ( mouseButton == 0 && ChiselsAndBits.getConfig().enableVivecraftCompatibility )
+        {
+            this.mc.displayGuiScreen( (GuiScreen) null );
+
+            if ( this.mc.currentScreen == null )
+            {
+                this.mc.setIngameFocus();
+            }
+        }
+    }
 }

--- a/src/main/java/mod/chiselsandbits/config/ModConfig.java
+++ b/src/main/java/mod/chiselsandbits/config/ModConfig.java
@@ -35,6 +35,9 @@ public class ModConfig extends Configuration
 	// mod settings...
 	@Configured( category = "Integration Settings" )
 	public boolean ShowBitsInJEI;
+	
+	@Configured( category = "Integration Settings" )
+	public boolean enableVivecraftCompatibility;
 
 	@Configured( category = "Troubleshooting" )
 	public boolean enableAPITestingItem;
@@ -391,6 +394,7 @@ public class ModConfig extends Configuration
 		enableTapeMeasure = true;
 		enableBitSaw = true;
 		ShowBitsInJEI = false;
+		enableVivecraftCompatibility = false;
 	}
 
 	public ModConfig(

--- a/src/main/java/mod/chiselsandbits/core/ClientSide.java
+++ b/src/main/java/mod/chiselsandbits/core/ClientSide.java
@@ -75,6 +75,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.audio.PositionedSoundRecord;
 import net.minecraft.client.gui.GuiIngame;
 import net.minecraft.client.gui.ScaledResolution;
+import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.particle.Particle;
 import net.minecraft.client.particle.ParticleManager;
 import net.minecraft.client.renderer.GlStateManager;
@@ -555,6 +556,10 @@ public class ClientSide
 
 				if ( wasVisible == false )
 				{
+					if ( ChiselsAndBits.getConfig().enableVivecraftCompatibility )
+					{
+						ChiselsAndBitsMenu.instance.mc.currentScreen = (GuiScreen)ChiselsAndBitsMenu.instance;
+					}
 					ChiselsAndBitsMenu.instance.mc.inGameHasFocus = false;
 					ChiselsAndBitsMenu.instance.mc.mouseHelper.ungrabMouseCursor();
 				}


### PR DESCRIPTION
close #268 

Add the configuration option `enableVivecraftCompatibility` under the `Integration Settings` section. Setting this to true changes tool menu hotkey behavior from hold-to-open to press-to-open. Selecting a tool mode is achieved by clicking the mode instead of letting the menu close while hovering over the mode.

Default setting for this is false.