### PR TITLE
Fixed broken textures of JsonModelExport command output.

### DIFF
--- a/src/main/java/mod/chiselsandbits/commands/JsonModelExport.java
+++ b/src/main/java/mod/chiselsandbits/commands/JsonModelExport.java
@@ -132,7 +132,7 @@ public class JsonModelExport extends CommandBase
 
 				final ModelQuadReader mqr = new ModelQuadReader( "#" + System.identityHashCode( sprite ), sprite, quad.getFace(), cullFace );
 				quad.pipe( mqr );
-				final String newJSON = mqr.toString();
+				final String newJSON = mqr.toString( quad.getFace() );
 
 				String old = textures.get( sprite );
 				if ( old == null )

--- a/src/main/java/mod/chiselsandbits/render/helpers/ModelQuadReader.java
+++ b/src/main/java/mod/chiselsandbits/render/helpers/ModelQuadReader.java
@@ -106,8 +106,7 @@ public class ModelQuadReader extends BaseModelReader
 			U1 = U2;
 			U2 = tempU;
 		}
-
-		if (faceQuad == EnumFacing.UP)
+		else if ( faceQuad == EnumFacing.UP )
 		{
 			final int tempV = V1;
 			V1 = V2;

--- a/src/main/java/mod/chiselsandbits/render/helpers/ModelQuadReader.java
+++ b/src/main/java/mod/chiselsandbits/render/helpers/ModelQuadReader.java
@@ -81,23 +81,37 @@ public class ModelQuadReader extends BaseModelReader
 		}
 	}
 
-	@Override
-	public String toString()
+	public String toString(
+			EnumFacing faceQuad )
 	{
-		int U1 = 0, V1 = 0, U2 = 16, V2 = 16;
+		int U1 = 0, V1 = 16, U2 = 16, V2 = 0;
 
 		for ( int idx = 0; idx < 4; idx++ )
 		{
 			if ( matches( minX, minY, minZ, pos_uv[idx] ) )
 			{
 				U1 = pos_uv[idx][3];
-				V1 = pos_uv[idx][4];
+				V2 = pos_uv[idx][4];
 			}
 			else if ( matches( maxX, maxY, maxZ, pos_uv[idx] ) )
 			{
 				U2 = pos_uv[idx][3];
-				V2 = pos_uv[idx][4];
+				V1 = pos_uv[idx][4];
 			}
+		}
+
+		if ( faceQuad.getHorizontalIndex() > 1 )
+		{
+			final int tempU = U1;
+			U1 = U2;
+			U2 = tempU;
+		}
+
+		if (faceQuad == EnumFacing.UP)
+		{
+			final int tempV = V1;
+			V1 = V2;
+			V2 = tempV;
 		}
 
 		if ( cull == null )


### PR DESCRIPTION
I was recently using the command to generate json models for some new items, and found that the textures of all faces but _up_ are incorrect. I have no idea why, but for whatever reason:
1. V1 and V2 must be swapped for all but _up_.
2. U1 and U2 must be swapped for _north_ and _east_.

What I did to fix it was:
1. Swap the declared and set values of the Vs, then swap them back with a temp int in the case of _up_.
2. Let the Us remain as is, but swap them with a temp int for faces with a horizontalIndex > 1 (why that is so, I again have no idea, but it's the only value I saw in common between _north_ and _east_, but no other).

Since I only found what needed to be changed by trial and error with the help of a Python script, I don't know if there is some deeper root to the problem (and if so, if affects anything other than the command), but if not (or if it's not worth changing), this does fix the problem for the command.