### PR TITLE
Restored default background and stack hover text rendering in Bit Bag GUI.

### DIFF
--- a/src/main/java/mod/chiselsandbits/bitbag/BagGui.java
+++ b/src/main/java/mod/chiselsandbits/bitbag/BagGui.java
@@ -77,6 +77,17 @@ public class BagGui extends GuiContainer
 	}
 
 	@Override
+	public void drawScreen(
+			final int mouseX,
+			final int mouseY,
+			final float partialTicks )
+	{
+		drawDefaultBackground();
+		super.drawScreen( mouseX, mouseY, partialTicks );
+		func_191948_b( mouseX, mouseY );
+	}
+
+	@Override
 	protected void drawGuiContainerBackgroundLayer(
 			final float partialTicks,
 			final int mouseX,


### PR DESCRIPTION
Has to be done manually in 1.12... For every GuiContainer implementer... This exact method is duplicated in 7 vanilla classes, such as GuiChest and GuiFurnace...

Once they extracted hover text rendering from drawScreen as a separate method (renderHoveredToolTip), instead of then extracting the rest of drawScreen to a separate method (which would have left the default implementation of drawScreen as nearly a carbon copy of this method), they just removed drawDefaultBackground and renderHoveredToolTip, and copy/pasted this method everywhere...

Oh well.