### PR TITLE
Modified item rendering.

### DIFF
--- a/src/main/java/mod/chiselsandbits/render/BaseBakedPerspectiveModel.java
+++ b/src/main/java/mod/chiselsandbits/render/BaseBakedPerspectiveModel.java
@@ -26,59 +26,29 @@ public abstract class BaseBakedPerspectiveModel implements IBakedModel
 		// for some reason these are not identical to vanilla's Block.json, I
 		// don't know why.. but its close.
 
-		{
-			final javax.vecmath.Vector3f translation = new javax.vecmath.Vector3f( 0, 0, 0 );
-			final javax.vecmath.Vector3f scale = new javax.vecmath.Vector3f( 0.625f, 0.625f, 0.625f );
-			final Quat4f rotation = TRSRTransformation.quatFromXYZDegrees( new javax.vecmath.Vector3f( 30, 225, 0 ) );
+		gui = getMatrix( 0, 0, 0, 30, 225, 0, 0.625f );
+		ground = getMatrix( 0, 0, 0, 0, 0, 0, 0.25f );
+		fixed = getMatrix( 0, 0, 0, 0, 0, 0, 0.5f );
+		thirdPerson_lefthand = thirdPerson_righthand = getMatrix( 0, 0, 0, 75, 45, 0, 0.375f );
+		firstPerson_righthand = getMatrix( 0, 0, 0, 0, 45, 0, 0.40f );
+		firstPerson_lefthand = getMatrix( 0, 0, 0, 0, 0, 225, 0.40f );
+	}
 
-			final TRSRTransformation transform = new TRSRTransformation( translation, rotation, scale, null );
-			gui = transform.getMatrix();
-		}
+	private static Matrix4f getMatrix(
+			final float transX,
+			final float transY,
+			final float transZ,
+			final float rotX,
+			final float rotY,
+			final float rotZ,
+			final float scaleXYZ )
+	{
+		final javax.vecmath.Vector3f translation = new javax.vecmath.Vector3f( transX, transY, transZ );
+		final javax.vecmath.Vector3f scale = new javax.vecmath.Vector3f( scaleXYZ, scaleXYZ, scaleXYZ );
+		final Quat4f rotation = TRSRTransformation.quatFromXYZDegrees( new javax.vecmath.Vector3f( rotX, rotY, rotZ ) );
 
-		{
-			final javax.vecmath.Vector3f translation = new javax.vecmath.Vector3f( 0, 0, 0 );
-			final javax.vecmath.Vector3f scale = new javax.vecmath.Vector3f( 0.25f, 0.25f, 0.25f );
-			final Quat4f rotation = TRSRTransformation.quatFromXYZDegrees( new javax.vecmath.Vector3f( 0, 0, 0 ) );
-
-			final TRSRTransformation transform = new TRSRTransformation( translation, rotation, scale, null );
-			ground = transform.getMatrix();
-		}
-
-		{
-			final javax.vecmath.Vector3f translation = new javax.vecmath.Vector3f( 0, 0, 0 );
-			final javax.vecmath.Vector3f scale = new javax.vecmath.Vector3f( 0.5f, 0.5f, 0.5f );
-			final Quat4f rotation = TRSRTransformation.quatFromXYZDegrees( new javax.vecmath.Vector3f( 0, 0, 0 ) );
-
-			final TRSRTransformation transform = new TRSRTransformation( translation, rotation, scale, null );
-			fixed = transform.getMatrix();
-		}
-
-		{
-			final javax.vecmath.Vector3f translation = new javax.vecmath.Vector3f( 0, 0, 0 );
-			final javax.vecmath.Vector3f scale = new javax.vecmath.Vector3f( 0.375f, 0.375f, 0.375f );
-			final Quat4f rotation = TRSRTransformation.quatFromXYZDegrees( new javax.vecmath.Vector3f( 75, 45, 0 ) );
-
-			final TRSRTransformation transform = new TRSRTransformation( translation, rotation, scale, null );
-			thirdPerson_lefthand = thirdPerson_righthand = transform.getMatrix();
-		}
-
-		{
-			final javax.vecmath.Vector3f translation = new javax.vecmath.Vector3f( 0, 0, 0 );
-			final javax.vecmath.Vector3f scale = new javax.vecmath.Vector3f( 0.40f, 0.40f, 0.40f );
-			final Quat4f rotation = TRSRTransformation.quatFromXYZDegrees( new javax.vecmath.Vector3f( 0, 45, 0 ) );
-
-			final TRSRTransformation transform = new TRSRTransformation( translation, rotation, scale, null );
-			firstPerson_righthand = transform.getMatrix();
-		}
-
-		{
-			final javax.vecmath.Vector3f translation = new javax.vecmath.Vector3f( 0, 0, 0 );
-			final javax.vecmath.Vector3f scale = new javax.vecmath.Vector3f( 0.40f, 0.40f, 0.40f );
-			final Quat4f rotation = TRSRTransformation.quatFromXYZDegrees( new javax.vecmath.Vector3f( 0, 225, 0 ) );
-
-			final TRSRTransformation transform = new TRSRTransformation( translation, rotation, scale, null );
-			firstPerson_lefthand = transform.getMatrix();
-		}
+		final TRSRTransformation transform = new TRSRTransformation( translation, rotation, scale, null );
+		return transform.getMatrix();
 	}
 
 	@Override

--- a/src/main/java/mod/chiselsandbits/render/BaseBakedPerspectiveModel.java
+++ b/src/main/java/mod/chiselsandbits/render/BaseBakedPerspectiveModel.java
@@ -23,13 +23,10 @@ public abstract class BaseBakedPerspectiveModel implements IBakedModel
 
 	static
 	{
-		// for some reason these are not identical to vanilla's Block.json, I
-		// don't know why.. but its close.
-
 		gui = getMatrix( 0, 0, 0, 30, 225, 0, 0.625f );
-		ground = getMatrix( 0, 0, 0, 0, 0, 0, 0.25f );
+		ground = getMatrix( 0, 3 / 16.0f, 0, 0, 0, 0, 0.25f );
 		fixed = getMatrix( 0, 0, 0, 0, 0, 0, 0.5f );
-		thirdPerson_lefthand = thirdPerson_righthand = getMatrix( 0, 0, 0, 75, 45, 0, 0.375f );
+		thirdPerson_lefthand = thirdPerson_righthand = getMatrix( 0, 2.5f / 16.0f, 0, 75, 45, 0, 0.375f );
 		firstPerson_righthand = getMatrix( 0, 0, 0, 0, 45, 0, 0.40f );
 		firstPerson_lefthand = getMatrix( 0, 0, 0, 0, 0, 225, 0.40f );
 	}

--- a/src/main/resources/assets/chiselsandbits/models/item/bit_bag.json
+++ b/src/main/resources/assets/chiselsandbits/models/item/bit_bag.json
@@ -1,5 +1,5 @@
 {
-    "parent":"item/handheld",
+    "parent":"item/generated",
     "textures": {
         "layer0":"chiselsandbits:items/bit_bag"
     }

--- a/src/main/resources/assets/chiselsandbits/models/item/bitsaw_diamond.json
+++ b/src/main/resources/assets/chiselsandbits/models/item/bitsaw_diamond.json
@@ -1,18 +1,18 @@
 {
-	"parent": "item/generated",
+    "parent":"item/generated",
 	"textures": {
 		"layer0":"chiselsandbits:items/bitsaw_diamond"
 	},
 	"display": {
 		"thirdperson_righthand": {
 			"rotation": [ 0, 90, 55 ],
-			"translation": [ 0, 4.0, 0.5 ],
-			"scale": [ 0.85, 0.85, 0.85 ]
+			"translation": [ 0, 3.5, 0.75 ],
+			"scale": [ 0.55, 0.55, 0.55 ]
 		},
 		"thirdperson_lefthand": {
 			"rotation": [ 0, -90, -55 ],
-			"translation": [ 0, 4.0, 0.5 ],
-			"scale": [ 0.85, 0.85, 0.85 ]
+			"translation": [ 0, 3.5, 0.75 ],
+			"scale": [ 0.55, 0.55, 0.55 ]
 		},
 		"firstperson_righthand": {
 			"rotation": [ 0, 90, 25 ],

--- a/src/main/resources/assets/chiselsandbits/models/item/chisel_diamond.json
+++ b/src/main/resources/assets/chiselsandbits/models/item/chisel_diamond.json
@@ -1,5 +1,5 @@
 {
-    "parent":"item/handheld",
+    "parent":"chiselsandbits:item/tool",
     "textures": {
         "layer0":"chiselsandbits:items/chisel_diamond"
     }

--- a/src/main/resources/assets/chiselsandbits/models/item/chisel_gold.json
+++ b/src/main/resources/assets/chiselsandbits/models/item/chisel_gold.json
@@ -1,5 +1,5 @@
 {
-    "parent":"item/handheld",
+    "parent":"chiselsandbits:item/tool",
     "textures": {
         "layer0":"chiselsandbits:items/chisel_gold"
     }

--- a/src/main/resources/assets/chiselsandbits/models/item/chisel_iron.json
+++ b/src/main/resources/assets/chiselsandbits/models/item/chisel_iron.json
@@ -1,5 +1,5 @@
 {
-    "parent":"item/handheld",
+    "parent":"chiselsandbits:item/tool",
     "textures": {
         "layer0":"chiselsandbits:items/chisel_iron"
     }

--- a/src/main/resources/assets/chiselsandbits/models/item/chisel_stone.json
+++ b/src/main/resources/assets/chiselsandbits/models/item/chisel_stone.json
@@ -1,5 +1,5 @@
 {
-    "parent":"item/handheld",
+    "parent":"chiselsandbits:item/tool",
     "textures": {
         "layer0":"chiselsandbits:items/chisel_stone"
     }

--- a/src/main/resources/assets/chiselsandbits/models/item/mirrorprint.json
+++ b/src/main/resources/assets/chiselsandbits/models/item/mirrorprint.json
@@ -1,5 +1,5 @@
 {
-    "parent":"item/handheld",
+    "parent":"item/generated",
     "textures": {
         "layer0":"chiselsandbits:items/mirrorprint"
     }

--- a/src/main/resources/assets/chiselsandbits/models/item/mirrorprint_written.json
+++ b/src/main/resources/assets/chiselsandbits/models/item/mirrorprint_written.json
@@ -1,5 +1,5 @@
 {
-    "parent":"item/handheld",
+    "parent":"item/generated",
     "textures": {
         "layer0":"chiselsandbits:items/mirrorprint_written"
     }

--- a/src/main/resources/assets/chiselsandbits/models/item/negativeprint.json
+++ b/src/main/resources/assets/chiselsandbits/models/item/negativeprint.json
@@ -1,5 +1,5 @@
 {
-    "parent":"item/handheld",
+    "parent":"item/generated",
     "textures": {
         "layer0":"chiselsandbits:items/negativeprint"
     }

--- a/src/main/resources/assets/chiselsandbits/models/item/negativeprint_written.json
+++ b/src/main/resources/assets/chiselsandbits/models/item/negativeprint_written.json
@@ -1,5 +1,5 @@
 {
-    "parent":"item/handheld",
+    "parent":"item/generated",
     "textures": {
         "layer0":"chiselsandbits:items/negativeprint_written"
     }

--- a/src/main/resources/assets/chiselsandbits/models/item/positiveprint.json
+++ b/src/main/resources/assets/chiselsandbits/models/item/positiveprint.json
@@ -1,5 +1,5 @@
 {
-    "parent":"item/handheld",
+    "parent":"item/generated",
     "textures": {
         "layer0":"chiselsandbits:items/positiveprint"
     }

--- a/src/main/resources/assets/chiselsandbits/models/item/positiveprint_written.json
+++ b/src/main/resources/assets/chiselsandbits/models/item/positiveprint_written.json
@@ -1,5 +1,5 @@
 {
-    "parent":"item/handheld",
+    "parent":"item/generated",
     "textures": {
         "layer0":"chiselsandbits:items/positiveprint_written"
     }

--- a/src/main/resources/assets/chiselsandbits/models/item/tape_measure.json
+++ b/src/main/resources/assets/chiselsandbits/models/item/tape_measure.json
@@ -1,5 +1,5 @@
 {
-    "parent":"item/handheld",
+    "parent":"item/generated",
     "textures": {
         "layer0":"chiselsandbits:items/tape_measure"
     }

--- a/src/main/resources/assets/chiselsandbits/models/item/tool.json
+++ b/src/main/resources/assets/chiselsandbits/models/item/tool.json
@@ -1,0 +1,15 @@
+{
+    "parent": "item/handheld",
+	"display": {
+        "thirdperson_righthand": {
+            "rotation": [ 0, -90, 55 ],
+            "translation": [ 0, 3.5, 0.75 ],
+            "scale": [ 0.55, 0.55, 0.55 ]
+        },
+        "thirdperson_lefthand": {
+            "rotation": [ 0, 90, -55 ],
+            "translation": [ 0, 3.5, 0.75 ],
+            "scale": [ 0.55, 0.55, 0.55 ]
+        }
+    }
+}

--- a/src/main/resources/assets/chiselsandbits/models/item/wrench_wood.json
+++ b/src/main/resources/assets/chiselsandbits/models/item/wrench_wood.json
@@ -1,5 +1,5 @@
 {
-    "parent":"item/handheld",
+    "parent":"chiselsandbits:item/tool",
     "textures": {
         "layer0":"chiselsandbits:items/wrench_wood"
     }


### PR DESCRIPTION
**Changes**
1. Designs, tape measures, and bit bags render as they did before.
2. Chisels, wrenches, and saws render as a scaled-down version of item/handheld.
3. Fixed long-standing bug where perspective models didn't render exactly as block.json specifies.
    - To visualize: place a block in one hand, a chiseled block in the other, enter 3rd person, then swap them back and forth with F.

The item/generated of normal items is at 0.55 scale, while item/handheld is at 0.85 scale. I tried everything in between, but ultimately decided that keeping the 0.55 scale of normal items looked the best (the rotation is the same as item/handheld):

![Scaled-Down Render First Person](https://s26.postimg.org/7urgx6cdl/Scaled-Down_Render_First_Person.png)
![Scaled-Down Render Third Person](https://s26.postimg.org/5ox62o8x5/Scaled-Down_Render_Third_Person.png)

If you disagree, feel free to change the scale it to anything you want (in both bitsaw_diamond.json and tool.json); just bear in mind that if you do, the translation needs a small bit of tweaking for a scale less than 0.85 (as I did for 0.55).

Resolves #305

Also, I can confirm that the changes made here, and the removal of the "thirdperson" and "firstperson" display elements in b8e5491, all work just fine in 1.11.2 and 1.10.2.