### PR TITLE
Suggestion - Two new configuration options to add #365

### DIFF
--- a/src/main/java/mod/chiselsandbits/config/ModConfig.java
+++ b/src/main/java/mod/chiselsandbits/config/ModConfig.java
@@ -275,7 +275,7 @@ public class ModConfig extends Configuration
 
 	@Configured( category = "Balance Settings" )
 	public int bagStackSize;
-	
+
 	@Configured( category = "Balance Settings" )
 	public int stoneChiselUses;
 

--- a/src/main/java/mod/chiselsandbits/config/ModConfig.java
+++ b/src/main/java/mod/chiselsandbits/config/ModConfig.java
@@ -275,7 +275,7 @@ public class ModConfig extends Configuration
 
 	@Configured( category = "Balance Settings" )
 	public int bagStackSize;
-
+	
 	@Configured( category = "Balance Settings" )
 	public int stoneChiselUses;
 
@@ -299,6 +299,12 @@ public class ModConfig extends Configuration
 
 	@Configured( category = "Balance Settings" )
 	public boolean fullBlockCrafting;
+		
+	@Configured( category = "Balance Settings" )
+	public boolean requireBagSpace;
+	
+	@Configured( category = "Balance Settings" )
+	public boolean voidExcessBits;
 
 	// in game state
 	public boolean replaceingBits = false;
@@ -360,6 +366,8 @@ public class ModConfig extends Configuration
 		compatabilityMode = true;
 		maxDrawnRegionSize = 4;
 		bagStackSize = 512;
+		requireBagSpace = false;
+		voidExcessBits = false;
 		maxUndoLevel = 32;
 		maxTapeMeasures = 5;
 

--- a/src/main/java/mod/chiselsandbits/helpers/ModUtil.java
+++ b/src/main/java/mod/chiselsandbits/helpers/ModUtil.java
@@ -1,21 +1,28 @@
 package mod.chiselsandbits.helpers;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
 
 import javax.annotation.Nonnull;
 
 import org.apache.commons.lang3.tuple.Pair;
 
 import mod.chiselsandbits.bitbag.BagInventory;
-import mod.chiselsandbits.chiseledblock.*;
+import mod.chiselsandbits.chiseledblock.ItemBlockChiseled;
+import mod.chiselsandbits.chiseledblock.NBTBlobConverter;
+import mod.chiselsandbits.chiseledblock.TileEntityBlockChiseled;
 import mod.chiselsandbits.chiseledblock.data.IntegerBox;
 import mod.chiselsandbits.chiseledblock.data.VoxelBlob;
 import mod.chiselsandbits.core.ChiselsAndBits;
 import mod.chiselsandbits.helpers.StateLookup.CachedStateLookup;
 import mod.chiselsandbits.integration.mcmultipart.MCMultipartProxy;
 import mod.chiselsandbits.integration.mods.LittleTiles;
-import mod.chiselsandbits.items.*;
+import mod.chiselsandbits.items.ItemBitBag;
 import mod.chiselsandbits.items.ItemBitBag.BagPos;
+import mod.chiselsandbits.items.ItemChiseledBit;
+import mod.chiselsandbits.items.ItemNegativePrint;
+import mod.chiselsandbits.items.ItemPositivePrint;
 import net.minecraft.block.Block;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.EntityLivingBase;
@@ -25,15 +32,20 @@ import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.SoundEvents;
 import net.minecraft.inventory.IInventory;
-import net.minecraft.item.*;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemBlock;
+import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.EnumFacing.Axis;
 import net.minecraft.util.SoundCategory;
-import net.minecraft.util.math.*;
-import net.minecraft.util.text.TextComponentTranslation;
-import net.minecraft.world.*;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.MathHelper;
+import net.minecraft.util.math.Vec3d;
+import net.minecraft.world.ChunkCache;
+import net.minecraft.world.IBlockAccess;
+import net.minecraft.world.World;
 import net.minecraft.world.chunk.Chunk;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.entity.player.EntityItemPickupEvent;

--- a/src/main/java/mod/chiselsandbits/helpers/ModUtil.java
+++ b/src/main/java/mod/chiselsandbits/helpers/ModUtil.java
@@ -1,28 +1,21 @@
 package mod.chiselsandbits.helpers;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Random;
+import java.util.*;
 
 import javax.annotation.Nonnull;
 
 import org.apache.commons.lang3.tuple.Pair;
 
 import mod.chiselsandbits.bitbag.BagInventory;
-import mod.chiselsandbits.chiseledblock.ItemBlockChiseled;
-import mod.chiselsandbits.chiseledblock.NBTBlobConverter;
-import mod.chiselsandbits.chiseledblock.TileEntityBlockChiseled;
+import mod.chiselsandbits.chiseledblock.*;
 import mod.chiselsandbits.chiseledblock.data.IntegerBox;
 import mod.chiselsandbits.chiseledblock.data.VoxelBlob;
 import mod.chiselsandbits.core.ChiselsAndBits;
 import mod.chiselsandbits.helpers.StateLookup.CachedStateLookup;
 import mod.chiselsandbits.integration.mcmultipart.MCMultipartProxy;
 import mod.chiselsandbits.integration.mods.LittleTiles;
-import mod.chiselsandbits.items.ItemBitBag;
+import mod.chiselsandbits.items.*;
 import mod.chiselsandbits.items.ItemBitBag.BagPos;
-import mod.chiselsandbits.items.ItemChiseledBit;
-import mod.chiselsandbits.items.ItemNegativePrint;
-import mod.chiselsandbits.items.ItemPositivePrint;
 import net.minecraft.block.Block;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.EntityLivingBase;
@@ -32,20 +25,15 @@ import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.SoundEvents;
 import net.minecraft.inventory.IInventory;
-import net.minecraft.item.Item;
-import net.minecraft.item.ItemBlock;
-import net.minecraft.item.ItemStack;
+import net.minecraft.item.*;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.EnumFacing.Axis;
 import net.minecraft.util.SoundCategory;
-import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.math.MathHelper;
-import net.minecraft.util.math.Vec3d;
-import net.minecraft.world.ChunkCache;
-import net.minecraft.world.IBlockAccess;
-import net.minecraft.world.World;
+import net.minecraft.util.math.*;
+import net.minecraft.util.text.TextComponentTranslation;
+import net.minecraft.world.*;
 import net.minecraft.world.chunk.Chunk;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.entity.player.EntityItemPickupEvent;
@@ -371,7 +359,7 @@ public class ModUtil
 		ItemStack is = ModUtil.nonNull( ei.getEntityItem() );
 
 		final List<BagPos> bags = ItemBitBag.getBags( player.inventory );
-
+		
 		if ( !containsAtLeastOneOf( player.inventory, is ) )
 		{
 			final ItemStack minSize = is.copy();
@@ -411,7 +399,11 @@ public class ModUtil
 				if ( is != null && !player.inventory.addItemStackToInventory( is ) )
 				{
 					ei.setEntityItemStack( is );
-					spawnItem( world, ei );
+					//Never spawn the items for dropped excess items if setting is enabled.
+					if ( !ChiselsAndBits.getConfig().voidExcessBits )
+					{
+						spawnItem( world, ei );
+					}
 				}
 				else
 				{

--- a/src/main/java/mod/chiselsandbits/helpers/ModUtil.java
+++ b/src/main/java/mod/chiselsandbits/helpers/ModUtil.java
@@ -371,7 +371,7 @@ public class ModUtil
 		ItemStack is = ModUtil.nonNull( ei.getEntityItem() );
 
 		final List<BagPos> bags = ItemBitBag.getBags( player.inventory );
-		
+
 		if ( !containsAtLeastOneOf( player.inventory, is ) )
 		{
 			final ItemStack minSize = is.copy();

--- a/src/main/java/mod/chiselsandbits/items/ItemBitBag.java
+++ b/src/main/java/mod/chiselsandbits/items/ItemBitBag.java
@@ -321,7 +321,7 @@ public class ItemBitBag extends Item
 
 	public static boolean hasBagSpace(
 			final EntityPlayer player,
-			final int stateId )
+			final int blk )
 	{
 		final List<BagPos> bags = getBags( player.inventory );
 		for ( final BagPos bp : bags )
@@ -329,7 +329,7 @@ public class ItemBitBag extends Item
 			for ( int x = 0; x < bp.inv.getSizeInventory(); x++ )
 			{
 				final ItemStack is = bp.inv.getStackInSlot( x );
-				if( ( ItemChiseledBit.getStackState( is ) == stateId && ModUtil.getStackSize( is ) < bp.inv.getInventoryStackLimit() ) || ModUtil.isEmpty( is ) ) {
+				if( ( ItemChiseledBit.sameBit( is, blk ) && ModUtil.getStackSize( is ) < bp.inv.getInventoryStackLimit() ) || ModUtil.isEmpty( is ) ) {
 					return true;
 				}
 			}

--- a/src/main/java/mod/chiselsandbits/items/ItemBitBag.java
+++ b/src/main/java/mod/chiselsandbits/items/ItemBitBag.java
@@ -319,4 +319,24 @@ public class ItemBitBag extends Item
 		return 0;
 	}
 
+	public static boolean hasBagSpace(
+			final EntityPlayer player,
+			final int stateId )
+	{
+		boolean ret = false;
+		final List<BagPos> bags = getBags( player.inventory );
+		for ( final BagPos bp : bags )
+		{
+			for ( int x = 0; x < bp.inv.getSizeInventory(); x++ )
+			{
+				final ItemStack is = bp.inv.getStackInSlot( x );
+				if( ( ItemChiseledBit.getStackState( is ) == stateId && ModUtil.getStackSize( is ) < bp.inv.getInventoryStackLimit() ) || ModUtil.isEmpty( is ) ) {
+					ret = true;
+					break;
+				}
+			}
+		}
+		return ret;
+	}
+
 }

--- a/src/main/java/mod/chiselsandbits/items/ItemBitBag.java
+++ b/src/main/java/mod/chiselsandbits/items/ItemBitBag.java
@@ -323,7 +323,6 @@ public class ItemBitBag extends Item
 			final EntityPlayer player,
 			final int stateId )
 	{
-		boolean ret = false;
 		final List<BagPos> bags = getBags( player.inventory );
 		for ( final BagPos bp : bags )
 		{
@@ -331,12 +330,11 @@ public class ItemBitBag extends Item
 			{
 				final ItemStack is = bp.inv.getStackInSlot( x );
 				if( ( ItemChiseledBit.getStackState( is ) == stateId && ModUtil.getStackSize( is ) < bp.inv.getInventoryStackLimit() ) || ModUtil.isEmpty( is ) ) {
-					ret = true;
-					break;
+					return true;
 				}
 			}
 		}
-		return ret;
+		return false;
 	}
 
 }

--- a/src/main/java/mod/chiselsandbits/items/ItemBitBag.java
+++ b/src/main/java/mod/chiselsandbits/items/ItemBitBag.java
@@ -329,7 +329,8 @@ public class ItemBitBag extends Item
 			for ( int x = 0; x < bp.inv.getSizeInventory(); x++ )
 			{
 				final ItemStack is = bp.inv.getStackInSlot( x );
-				if( ( ItemChiseledBit.sameBit( is, blk ) && ModUtil.getStackSize( is ) < bp.inv.getInventoryStackLimit() ) || ModUtil.isEmpty( is ) ) {
+				if( ( ItemChiseledBit.sameBit( is, blk ) && ModUtil.getStackSize( is ) < bp.inv.getInventoryStackLimit() ) || ModUtil.isEmpty( is ) )
+				{
 					return true;
 				}
 			}

--- a/src/main/java/mod/chiselsandbits/items/ItemChisel.java
+++ b/src/main/java/mod/chiselsandbits/items/ItemChisel.java
@@ -143,7 +143,7 @@ public class ItemChisel extends ItemTool implements IItemScrollWheel, IChiselMod
 		{
 			//Cycle every item in any bag, if the player can't store the clicked block then
 			//send them a message.
-			final int stateId = ModUtil.getStateId( player.worldObj.getBlockState( pos ) );
+			final int stateId = ModUtil.getStateId( state );
 			if ( !ItemBitBag.hasBagSpace( player, stateId ) )
 			{
 				if( player.worldObj.isRemote && !pos.equals( lastPos ) )

--- a/src/main/java/mod/chiselsandbits/items/ItemChisel.java
+++ b/src/main/java/mod/chiselsandbits/items/ItemChisel.java
@@ -30,7 +30,6 @@ import mod.chiselsandbits.integration.mcmultipart.MCMultipartProxy;
 import mod.chiselsandbits.integration.mods.LittleTiles;
 import mod.chiselsandbits.interfaces.IChiselModeItem;
 import mod.chiselsandbits.interfaces.IItemScrollWheel;
-import mod.chiselsandbits.items.ItemBitBag.BagPos;
 import mod.chiselsandbits.modes.ChiselMode;
 import mod.chiselsandbits.modes.IToolMode;
 import mod.chiselsandbits.network.NetworkRouter;
@@ -129,6 +128,9 @@ public class ItemChisel extends ItemTool implements IItemScrollWheel, IChiselMod
 		return ItemChisel.fromBreakToChisel( ChiselMode.castMode( ChiselModeManager.getChiselMode( player, ChiselToolType.CHISEL, EnumHand.MAIN_HAND ) ), itemstack, pos, player, EnumHand.MAIN_HAND );
 	}
 
+	//The previous stateId, avoids spamming the require_bag message.
+	private static BlockPos lastPos = new BlockPos(0, -1, 0);
+
 	static public boolean fromBreakToChisel(
 			final ChiselMode mode,
 			final ItemStack itemstack,
@@ -137,29 +139,18 @@ public class ItemChisel extends ItemTool implements IItemScrollWheel, IChiselMod
 			final EnumHand hand )
 	{
 		final IBlockState state = player.getEntityWorld().getBlockState( pos );
-		if( ChiselsAndBits.getConfig().requireBagSpace && !player.isCreative() )
+		if ( ChiselsAndBits.getConfig().requireBagSpace && !player.isCreative() )
 		{
 			//Cycle every item in any bag, if the player can't store the clicked block then
 			//send them a message.
-			final List<BagPos> bags = ItemBitBag.getBags( player.inventory );
-			boolean noAvailableBagSpace = true;
-			for ( final BagPos bp : bags )
+			final int stateId = ModUtil.getStateId( player.worldObj.getBlockState( pos ) );
+			if ( !ItemBitBag.hasBagSpace( player, stateId ) )
 			{
-				for ( int x = 0; x < bp.inv.getSizeInventory(); x++ )
+				if( player.worldObj.isRemote && !pos.equals( lastPos ) )
 				{
-					final ItemStack is = bp.inv.getStackInSlot( x );
-					if( ( ModUtil.getStateId( player.worldObj.getBlockState( pos ) ) == ItemChiseledBit.getStackState( is ) && ModUtil.getStackSize( is ) < bp.inv.getInventoryStackLimit()  ) || ModUtil.isEmpty( is ) ) {
-						noAvailableBagSpace = false;
-						break;
-					}
-				}
-			}
-			if( noAvailableBagSpace )
-			{
-				if( player.worldObj.isRemote )
-				{
-					//Client should handle messaging.
+					//Only client should handle messaging.
 					player.addChatMessage( new TextComponentTranslation( "mod.chiselsandbits.result.require_bag" ) );
+					lastPos = pos;
 				}
 				return false;
 			}

--- a/src/main/java/mod/chiselsandbits/items/ItemChisel.java
+++ b/src/main/java/mod/chiselsandbits/items/ItemChisel.java
@@ -301,7 +301,7 @@ public class ItemChisel extends ItemTool implements IItemScrollWheel, IChiselMod
 		final BitLocation location = new BitLocation( new RayTraceResult( RayTraceResult.Type.BLOCK, new Vec3d( hitX, hitY, hitZ ), side, pos ), false, BitOperation.CHISEL );
 
 		final PacketChisel pc = new PacketChisel( BitOperation.CHISEL, location, side, mode, hand );
-		
+
 		final int extractedState = pc.doAction( player );
 		if ( extractedState != 0 )
 		{

--- a/src/main/java/mod/chiselsandbits/items/ItemChiseledBit.java
+++ b/src/main/java/mod/chiselsandbits/items/ItemChiseledBit.java
@@ -466,7 +466,8 @@ public class ItemChiseledBit extends Item implements IItemScrollWheel, IChiselMo
 		for ( int x = 0; x < 36; x++ )
 		{
 			final ItemStack is = player.inventory.getStackInSlot( x );
-			if( ( ItemChiseledBit.sameBit( is, blk ) && ModUtil.getStackSize( is ) < is.getMaxStackSize() ) || ModUtil.isEmpty( is ) ) {
+			if( ( ItemChiseledBit.sameBit( is, blk ) && ModUtil.getStackSize( is ) < is.getMaxStackSize() ) || ModUtil.isEmpty( is ) )
+			{
 				return true;
 			}
 		}

--- a/src/main/java/mod/chiselsandbits/items/ItemChiseledBit.java
+++ b/src/main/java/mod/chiselsandbits/items/ItemChiseledBit.java
@@ -458,4 +458,18 @@ public class ItemChiseledBit extends Item implements IItemScrollWheel, IChiselMo
 
 		return false;
 	}
+
+	public static boolean hasInventorySpace(
+			final EntityPlayer player,
+			final int blk )
+	{
+		for ( int x = 0; x < 36; x++ )
+		{
+			final ItemStack is = player.inventory.getStackInSlot( x );
+			if( ( ItemChiseledBit.sameBit( is, blk ) && ModUtil.getStackSize( is ) < is.getMaxStackSize() ) || ModUtil.isEmpty( is ) ) {
+				return true;
+			}
+		}
+		return ItemBitBag.hasBagSpace( player, blk );
+	}
 }

--- a/src/main/java/mod/chiselsandbits/items/ItemNegativePrint.java
+++ b/src/main/java/mod/chiselsandbits/items/ItemNegativePrint.java
@@ -38,6 +38,7 @@ import net.minecraft.util.EnumFacing;
 import net.minecraft.util.EnumFacing.Axis;
 import net.minecraft.util.EnumHand;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.text.TextComponentTranslation;
 import net.minecraft.world.World;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
@@ -299,9 +300,32 @@ public class ItemNegativePrint extends Item implements IVoxelBlobItem, IItemScro
 			}
 		}
 
+		//The state id of the last item in spawnlist.
+		int entityItemState = 0;
+
 		for ( final EntityItem ei : spawnlist )
 		{
 			ModUtil.feedPlayer( world, who, ei );
+			entityItemState = ItemChiseledBit.getStackState( ei.getEntityItem() );
+		}
+
+		//entityItemState is always 0 when remote
+		if ( !world.isRemote && entityItemState != 0 )
+		{
+			if( ChiselsAndBits.getConfig().requireBagSpace )
+			{
+				if ( !ItemBitBag.hasBagSpace( who, entityItemState ) )
+				{
+					who.addChatMessage( new TextComponentTranslation( "mod.chiselsandbits.result.require_bag_full" ) );
+				}
+			}
+			else if( ChiselsAndBits.getConfig().voidExcessBits )
+			{
+				if( !ItemChiseledBit.hasInventorySpace( who, entityItemState ) )
+				{
+					who.addChatMessage( new TextComponentTranslation( "mod.chiselsandbits.result.void_excess" ) );
+				}
+			}
 		}
 	}
 

--- a/src/main/java/mod/chiselsandbits/network/packets/PacketChisel.java
+++ b/src/main/java/mod/chiselsandbits/network/packets/PacketChisel.java
@@ -218,20 +218,21 @@ public class PacketChisel extends ModPacket
 				entityItemState = ItemChiseledBit.getStackState( ei.getEntityItem() );
 			}
 
-			if ( world.isRemote && ( ChiselsAndBits.getConfig().requireBagSpace || ChiselsAndBits.getConfig().voidExcessBits ) )
+			//entityItemState is always 0 when remote
+			if ( !world.isRemote && entityItemState != 0 )
 			{
-				//Test if the fed items fill up the bag, then notify the player to make sure they don't waste
-				//resources.
-				//Only send messages on client side.
-				if ( !ItemBitBag.hasBagSpace( who, entityItemState ) )
+				if( ChiselsAndBits.getConfig().requireBagSpace )
 				{
-					if( ChiselsAndBits.getConfig().voidExcessBits )
-					{
-						who.addChatMessage( new TextComponentTranslation( "mod.chiselsandbits.result.void_excess" ) );
-					}
-					else
+					if ( !ItemBitBag.hasBagSpace( who, entityItemState ) )
 					{
 						who.addChatMessage( new TextComponentTranslation( "mod.chiselsandbits.result.require_bag_full" ) );
+					}
+				}
+				else if( ChiselsAndBits.getConfig().voidExcessBits )
+				{
+					if( !ItemChiseledBit.hasInventorySpace( who, entityItemState ) )
+					{
+						who.addChatMessage( new TextComponentTranslation( "mod.chiselsandbits.result.void_excess" ) );
 					}
 				}
 			}

--- a/src/main/java/mod/chiselsandbits/network/packets/PacketChisel.java
+++ b/src/main/java/mod/chiselsandbits/network/packets/PacketChisel.java
@@ -22,7 +22,6 @@ import mod.chiselsandbits.integration.mcmultipart.MCMultipartProxy;
 import mod.chiselsandbits.items.ItemBitBag;
 import mod.chiselsandbits.items.ItemChisel;
 import mod.chiselsandbits.items.ItemChiseledBit;
-import mod.chiselsandbits.items.ItemBitBag.BagPos;
 import mod.chiselsandbits.modes.ChiselMode;
 import mod.chiselsandbits.network.ModPacket;
 import net.minecraft.block.Block;
@@ -209,36 +208,22 @@ public class PacketChisel extends ModPacket
 				}
 			}
 			
-			//A list of all types of items in spawnlist. (should be 1)
-			ArrayList<Integer> stackStates = new ArrayList<>();
+			//The state id of the last item in spawnlist.
+			int entityItemState = 0;
 			
 			for ( final EntityItem ei : spawnlist )
 			{
 				ModUtil.feedPlayer( world, who, ei );
 				ItemBitBag.cleanupInventory( who, ei.getEntityItem() );
-				stackStates.add( ItemChiseledBit.getStackState( ei.getEntityItem() ) );
+				entityItemState = ItemChiseledBit.getStackState( ei.getEntityItem() );
 			}
 
-			final List<BagPos> bags = ItemBitBag.getBags( who.inventory );
-			
-			if( world.isRemote && ( ChiselsAndBits.getConfig().requireBagSpace || ChiselsAndBits.getConfig().voidExcessBits ) )
+			if ( world.isRemote && ( ChiselsAndBits.getConfig().requireBagSpace || ChiselsAndBits.getConfig().voidExcessBits ) )
 			{
 				//Test if the fed items fill up the bag, then notify the player to make sure they don't waste
 				//resources.
 				//Only send messages on client side.
-				boolean noAvailableBagSpace = true;
-				for ( final BagPos bp : bags )
-				{
-					for ( int x = 0; x < bp.inv.getSizeInventory(); x++ )
-					{
-						final ItemStack is = bp.inv.getStackInSlot( x );
-						if( ( stackStates.contains( ItemChiseledBit.getStackState( is ) ) && ModUtil.getStackSize( is ) < bp.inv.getInventoryStackLimit() ) || ModUtil.isEmpty( is ) ) {
-							noAvailableBagSpace = false;
-							break;
-						}
-					}
-				}
-				if( noAvailableBagSpace )
+				if ( !ItemBitBag.hasBagSpace( who, entityItemState ) )
 				{
 					if( ChiselsAndBits.getConfig().voidExcessBits )
 					{

--- a/src/main/resources/assets/chiselsandbits/lang/en_us.lang
+++ b/src/main/resources/assets/chiselsandbits/lang/en_us.lang
@@ -70,7 +70,7 @@ mod.chiselsandbits.result.has_changed=Block has changed
 mod.chiselsandbits.result.missing_bits=Not enough bits or chisel durability!
 mod.chiselsandbits.result.nothing_to_undo=Nothing to Undo
 mod.chiselsandbits.result.nothing_to_redo=Nothing to Redo
-mod.chiselsandbits.result.require_bag=You need more bag space before you can chisel!
+mod.chiselsandbits.result.require_bag=You need a bag which isn't full before you can use the chisel!
 mod.chiselsandbits.result.require_bag_full=Your bag has filled up!
 mod.chiselsandbits.result.void_excess=Your inventory has filled up, any excess bits have been voided!
 

--- a/src/main/resources/assets/chiselsandbits/lang/en_us.lang
+++ b/src/main/resources/assets/chiselsandbits/lang/en_us.lang
@@ -70,6 +70,9 @@ mod.chiselsandbits.result.has_changed=Block has changed
 mod.chiselsandbits.result.missing_bits=Not enough bits or chisel durability!
 mod.chiselsandbits.result.nothing_to_undo=Nothing to Undo
 mod.chiselsandbits.result.nothing_to_redo=Nothing to Redo
+mod.chiselsandbits.result.require_bag=You need more bag space before you can chisel!
+mod.chiselsandbits.result.require_bag_full=Your bag has filled up!
+mod.chiselsandbits.result.void_excess=Your inventory has filled up, any excess bits have been voided!
 
 mod.chiselsandbits.other.rotate.ccw=Rotate Held Counter Clockwise
 mod.chiselsandbits.other.rotate.cw=Rotate Held Clockwise
@@ -255,3 +258,7 @@ mod.chiselsandbits.config.enableVivecraftCompatibility=Enable Vivecraft Compatib
 mod.chiselsandbits.config.enableChiselCrafting=Enable Chiseling Blocks in Crafting Table
 mod.chiselsandbits.config.dynamicRenderFullChunksOnly=Dynamic Renderer Full Chunks Only
 mod.chiselsandbits.config.dynamicRenderFullChunksOnly.tooltip=Prevents Subdividing of dynamically rendered chunks into single blocks. This increases performance for most common cases ( chunks with a handful of complicated blocks ), but decreases performance for the worst cases ( chunks full of super complicated designs ).
+mod.chiselsandbits.config.requireBagSpace=Require Bag Space
+mod.chiselsandbits.config.requireBagSpace.tooltip=Requires there to be at least 1 more bit of storage space in any bag in the player's inventory before allowing you to use a chisel.
+mod.chiselsandbits.config.voidExcessBits=Void Excess Bits
+mod.chiselsandbits.config.voidExcessBits.tooltip=Voids any bits that couldn't be fit into a bag or your inventory. Improves server performance.

--- a/src/main/resources/assets/chiselsandbits/lang/en_us.lang
+++ b/src/main/resources/assets/chiselsandbits/lang/en_us.lang
@@ -70,7 +70,7 @@ mod.chiselsandbits.result.has_changed=Block has changed
 mod.chiselsandbits.result.missing_bits=Not enough bits or chisel durability!
 mod.chiselsandbits.result.nothing_to_undo=Nothing to Undo
 mod.chiselsandbits.result.nothing_to_redo=Nothing to Redo
-mod.chiselsandbits.result.require_bag=You need a bag which isn't full before you can use the chisel!
+mod.chiselsandbits.result.require_bag=You need a bag with empty slots before you can use the chisel!
 mod.chiselsandbits.result.require_bag_full=Your bag has filled up!
 mod.chiselsandbits.result.void_excess=Your inventory has filled up, any excess bits have been voided!
 
@@ -259,6 +259,6 @@ mod.chiselsandbits.config.enableChiselCrafting=Enable Chiseling Blocks in Crafti
 mod.chiselsandbits.config.dynamicRenderFullChunksOnly=Dynamic Renderer Full Chunks Only
 mod.chiselsandbits.config.dynamicRenderFullChunksOnly.tooltip=Prevents Subdividing of dynamically rendered chunks into single blocks. This increases performance for most common cases ( chunks with a handful of complicated blocks ), but decreases performance for the worst cases ( chunks full of super complicated designs ).
 mod.chiselsandbits.config.requireBagSpace=Require Bag Space
-mod.chiselsandbits.config.requireBagSpace.tooltip=Requires there to be at least 1 more bit of storage space in any bag in the player's inventory before allowing you to use a chisel.
+mod.chiselsandbits.config.requireBagSpace.tooltip=Requires there to be an empty slot in a bag in the player's inventory before allowing them to use the chisel.
 mod.chiselsandbits.config.voidExcessBits=Void Excess Bits
 mod.chiselsandbits.config.voidExcessBits.tooltip=Voids any bits that couldn't be fit into a bag or your inventory. Improves server performance.

--- a/src/main/resources/assets/chiselsandbits/lang/en_us.lang
+++ b/src/main/resources/assets/chiselsandbits/lang/en_us.lang
@@ -261,4 +261,4 @@ mod.chiselsandbits.config.dynamicRenderFullChunksOnly.tooltip=Prevents Subdividi
 mod.chiselsandbits.config.requireBagSpace=Require Bag Space
 mod.chiselsandbits.config.requireBagSpace.tooltip=Requires there to be an empty slot in a bag in the player's inventory before allowing them to use the chisel.
 mod.chiselsandbits.config.voidExcessBits=Void Excess Bits
-mod.chiselsandbits.config.voidExcessBits.tooltip=Voids any bits that couldn't be fit into a bag or your inventory. Improves server performance.
+mod.chiselsandbits.config.voidExcessBits.tooltip=Voids any bits that couldn't be fit into a bag or your inventory. Improves server performance. The undo action could have issues as some bits are voided.


### PR DESCRIPTION
This pull request included two new configuration options: "voidExcessBits" and "requireBagSpace" which solves #365. Void excess bits simply (if enabled) stops any item entities from being spawned into the world by the feedPlayer() method. Require bag space requires the user to have a bag with available slots before being allowed to chisel.
The pull request has one known 'bug' or issue, when clicking with the chisel the message stating you don't have enough space is sent twice. I've tried to fix this but couldn't find the cause (it wasn't the obvious getHand().equals(MAIN_HAND)).
(also when the options are disabled on a client and enabled on a server voidExcessBits will work but no message is sent and requireBagSpace will not, the config could be synced on serverjoin?)

Thanks for reading/looking at my pull request, I hope it will make it into the mod.