### PR TITLE
Fix bug where off-grid placement of blocks sometimes fails.

### DIFF
--- a/src/main/java/mod/chiselsandbits/chiseledblock/ItemBlockChiseled.java
+++ b/src/main/java/mod/chiselsandbits/chiseledblock/ItemBlockChiseled.java
@@ -99,7 +99,7 @@ public class ItemBlockChiseled extends ItemBlock implements IVoxelBlobItem, IIte
 			final EntityPlayer player,
 			final ItemStack stack )
 	{
-		return canPlaceBlockHere( worldIn, pos, side, player, stack, false );
+		return canPlaceBlockHere( worldIn, pos, side, player, stack, ClientSide.offGridPlacement( player ) );
 	}
 
 	public boolean vanillaStylePlacementTest(


### PR DESCRIPTION
After confirming that reverting d91f5ce0cdb373f3e31cc348444d0b847f820eb2 fixes this, I noticed that previously `canPlaceBlockHere` always checked `player.isSneaking()`, even when called from `canPlaceBlockOnSide`. I've restored that functionality by passing the replacement method for `player.isSneaking()` to `canPlaceBlockHere` in `canPlaceBlockOnSide`.