### PR TITLE
Fix for #605

### DIFF
--- a/src/main/java/mod/chiselsandbits/network/packets/PacketChisel.java
+++ b/src/main/java/mod/chiselsandbits/network/packets/PacketChisel.java
@@ -32,6 +32,8 @@ import net.minecraft.util.math.BlockRayTraceResult;
 import net.minecraft.util.math.vector.Vector3d;
 import net.minecraft.world.World;
 import net.minecraft.world.server.ServerWorld;
+import net.minecraftforge.common.util.BlockSnapshot;
+import net.minecraftforge.event.ForgeEventFactory;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -127,6 +129,12 @@ public class PacketChisel extends ModPacket
 
 						BlockState blkstate = world.getBlockState( pos );
 						Block blkObj = blkstate.getBlock();
+
+						BlockSnapshot blocksnapshot = BlockSnapshot.create(world.getDimensionKey(), world, pos);
+
+						if (ForgeEventFactory.onBlockPlace(player.getPlayer(), blocksnapshot, Direction.UP)) {
+							return 0;
+						}
 
 						if ( place.usesChisels() )
 						{


### PR DESCRIPTION
Basically fixes the issues described in #605

I sadly had to implement the check if a block at the given position can be modified in the network packet file, since the chisel item functions related to chiseling a block only get triggered on the client side but FTBChunks only cancels server side events.

If there's any suggestions/alternatives let me know!