### PR TITLE
Fix raytracing reach distance being too short when not in creative mode on Forge

### DIFF
--- a/platforms/forge/src/main/java/mod/chiselsandbits/forge/platform/entity/ForgeEntityInformationManager.java
+++ b/platforms/forge/src/main/java/mod/chiselsandbits/forge/platform/entity/ForgeEntityInformationManager.java
@@ -24,12 +24,6 @@ public class ForgeEntityInformationManager implements IEntityInformationManager
     public double getReachDistance(final Player player)
     {
         final AttributeInstance reachAttribute = player.getAttribute(ForgeMod.REACH_DISTANCE.get());
-        if (reachAttribute == null)
-        {
-            return player.isCreative() ? 5f : 4.5f;
-        }
-
-        final double reachAttributeValue = reachAttribute.getValue();
-        return player.isCreative() ? reachAttributeValue : reachAttributeValue - 0.5D;
+        return reachAttribute == null ? 5d : reachAttribute.getValue();
     }
 }


### PR DESCRIPTION
While making the last PR, I noticed that when in survival mode, the current wireframe preview stops rendering at a distance where you can still place the block. The issue is that throughout `common`, the API's `RayTracingUtils#rayTracePlayer` is used, which first gets the reach using `IEntityInformationManager#getReachDistance` which is separately implemented by Forge and Fabric. It then reduces the reach by 0.5 if not in creative mode, and performs the raytrace. That's a problem, since, although Fabric just returns 5d, Forge returns `player.isCreative() ? 5f : 4.5f;` if `LivingEntity#getAttribute` returns null, else it does the same creative mode reduction for its return value.

This means that on Forge, if you're not in creative, the reach is 0.5 less that what it should be. This PR fixes this by simply remove the creative checks from `ForgeEntityInformationManager#getReachDistance`, matching Fabric, and keeps the check in `RayTracingUtils#rayTracePlayer`.