### PR TITLE
Prevent config builder from returning a list of doubles the compiler thinks are floats

### DIFF
--- a/platforms/forge/src/main/java/mod/chiselsandbits/forge/platform/configuration/ForgeDelegateConfigurationBuilder.java
+++ b/platforms/forge/src/main/java/mod/chiselsandbits/forge/platform/configuration/ForgeDelegateConfigurationBuilder.java
@@ -43,7 +43,12 @@ public class ForgeDelegateConfigurationBuilder implements IConfigurationBuilder
     {
         keys.add(key + ".comment");
         builder.comment(translateToLocal(key + ".comment"));
-        return builder.defineList(key, defaultValue, t -> true)::get;
+        if (containedType != Float.class)
+            return builder.defineList(key, defaultValue, t -> true)::get;
+
+        List<Double> defaultValueAsDoubles = defaultValue.stream().map(f -> ((Float) f).doubleValue()).toList();
+        ForgeConfigSpec.ConfigValue<List<? extends Double>> doubleListValue = builder.defineList(key, defaultValueAsDoubles, t -> t instanceof Double);
+        return () -> doubleListValue.get().stream().map(d -> containedType.cast(d.floatValue())).toList();
     }
 
     @Override


### PR DESCRIPTION
In a config file, if a number has a decimal, it's interpreted as a double; otherwise as an integer. (there is no defineFloat in Forge's config builder) If you try to specify a list of floats Forge will return you a supplier of `List<? extends Float>`, but if you set a breakpoint, you'll see it's full of doubles (or integers, if the decimal is missing). The compiler will happily let you call float class methods, but actually calling them will throw a class cast exception at runtime , saying that Double can't be cast to Float. Now, you can just set the element validator to only allow floats, but since nothing is ever interpreted as a float, it will always fail and revert to the default value.

This PR addresses this by checking if the class passed is the Float class, and if it is, it first converts the default value list to a double list. Then it defines a double list config value, and returns a new supplier which, upon being called, retrieves the double list from the config value and converts it to a float list.