### PR TITLE
Prevent highlights, previews, and slot overlays from rendering in spectator mode

### DIFF
--- a/common/src/main/java/mod/chiselsandbits/client/logic/MeasurementsRenderHandler.java
+++ b/common/src/main/java/mod/chiselsandbits/client/logic/MeasurementsRenderHandler.java
@@ -2,13 +2,15 @@ package mod.chiselsandbits.client.logic;
 
 import com.mojang.blaze3d.vertex.PoseStack;
 import mod.chiselsandbits.client.render.MeasurementRenderer;
+import net.minecraft.client.Minecraft;
 
 public class MeasurementsRenderHandler
 {
 
     public static void renderMeasurements(final PoseStack poseStack)
     {
-        MeasurementRenderer.getInstance().renderMeasurements(poseStack);
+        if (Minecraft.getInstance().player != null && !Minecraft.getInstance().player.isSpectator())
+            MeasurementRenderer.getInstance().renderMeasurements(poseStack);
     }
 
 }

--- a/common/src/main/java/mod/chiselsandbits/client/logic/MultiStateBlockPreviewRenderHandler.java
+++ b/common/src/main/java/mod/chiselsandbits/client/logic/MultiStateBlockPreviewRenderHandler.java
@@ -33,7 +33,7 @@ public class MultiStateBlockPreviewRenderHandler
             return;
 
         final Player playerEntity = Minecraft.getInstance().player;
-        if (playerEntity == null)
+        if (playerEntity == null || playerEntity.isSpectator())
             return;
 
         final ItemStack heldStack = ItemStackUtils.getMultiStateItemStackFromPlayer(playerEntity);

--- a/common/src/main/java/mod/chiselsandbits/client/logic/SelectedObjectRenderHandler.java
+++ b/common/src/main/java/mod/chiselsandbits/client/logic/SelectedObjectRenderHandler.java
@@ -18,7 +18,7 @@ public class SelectedObjectRenderHandler
       final float partialTicks
     ) {
         final Player playerEntity = Minecraft.getInstance().player;
-        if (playerEntity == null)
+        if (playerEntity == null || playerEntity.isSpectator())
             return;
 
         final ItemStack heldStack = ItemStackUtils.getHighlightItemStackFromPlayer(playerEntity);

--- a/common/src/main/java/mod/chiselsandbits/client/logic/SlotOverlayRenderHandler.java
+++ b/common/src/main/java/mod/chiselsandbits/client/logic/SlotOverlayRenderHandler.java
@@ -3,17 +3,22 @@ package mod.chiselsandbits.client.logic;
 import com.mojang.blaze3d.vertex.PoseStack;
 import mod.chiselsandbits.client.render.SlotOverlayRenderManager;
 import net.minecraft.client.Minecraft;
+import net.minecraft.world.entity.player.Player;
 
 public class SlotOverlayRenderHandler
 {
     public static void renderSlotOverlays(final PoseStack poseStack) {
+        Player player = Minecraft.getInstance().player;
+        if (player == null || player.isSpectator())
+            return;
+
         int centerOfScreen = Minecraft.getInstance().getWindow().getGuiScaledWidth() / 2;
 
         for(int slotIndex = 0; slotIndex < 9; ++slotIndex) {
             int xOffset = centerOfScreen - 90 + slotIndex * 20 + 2;
             int yOffSet = Minecraft.getInstance().getWindow().getGuiScaledHeight() - 16 - 3;
 
-            SlotOverlayRenderManager.getInstance().renderSlot(xOffset, yOffSet, poseStack, Minecraft.getInstance().player.getInventory().items.get(slotIndex));
+            SlotOverlayRenderManager.getInstance().renderSlot(xOffset, yOffSet, poseStack, player.getInventory().items.get(slotIndex));
         }
     }
 }


### PR DESCRIPTION
I left out measurement rendering because it seems less directly tied to the player, but I can include it if you want.