### PR TITLE
Replace isCrouching checks with isShiftKeyDown checks to restore previous functionality

### DIFF
--- a/api/src/main/java/mod/chiselsandbits/api/item/chiseled/IChiseledBlockItem.java
+++ b/api/src/main/java/mod/chiselsandbits/api/item/chiseled/IChiseledBlockItem.java
@@ -37,7 +37,7 @@ public interface IChiseledBlockItem extends IMultiStateItem, IPlacementPreviewPr
     @Override
     default Vec3 getTargetedPosition(ItemStack heldStack, Player playerEntity, BlockHitResult blockRayTraceResult)
     {
-        return !playerEntity.isCrouching() ?
+        return !playerEntity.isShiftKeyDown() ?
                  Vec3.atLowerCornerOf(blockRayTraceResult.getBlockPos().offset(blockRayTraceResult.getDirection().getNormal()))
                  :
                    blockRayTraceResult.getLocation();

--- a/common/src/main/java/mod/chiselsandbits/block/BitStorageBlock.java
+++ b/common/src/main/java/mod/chiselsandbits/block/BitStorageBlock.java
@@ -195,7 +195,7 @@ public class BitStorageBlock extends Block implements EntityBlock, IBitBagAccept
 
         final BlockInformation containedState = storage.getContainedBlockInformation();
 
-        if (player.isCrouching() && (containedState != null)) {
+        if (player.isShiftKeyDown() && (containedState != null)) {
             final int maxAmountToInsert = bitInventory.getMaxInsertAmount(containedState);
             final int bitCountToInsert = Math.min(storage.getBits(), maxAmountToInsert);
 
@@ -209,7 +209,7 @@ public class BitStorageBlock extends Block implements EntityBlock, IBitBagAccept
             storage.insertBits(bitCountToInsert, containedState);
             bitInventory.extract(containedState, bitCountToInsert);
         }
-        else if (!player.isCrouching()) {
+        else if (!player.isShiftKeyDown()) {
             final Optional<BlockInformation> toExtractCandidate =
                 bitInventory.getContainedStates()
                   .entrySet()

--- a/common/src/main/java/mod/chiselsandbits/block/ChiseledBlock.java
+++ b/common/src/main/java/mod/chiselsandbits/block/ChiseledBlock.java
@@ -129,8 +129,8 @@ public class ChiseledBlock extends Block implements IMultiStateBlock, SimpleWate
         }
 
         if (
-          (!IClientConfiguration.getInstance().getInvertPickBlockBehaviour().get() && player.isCrouching()) ||
-          (IClientConfiguration.getInstance().getInvertPickBlockBehaviour().get() && !player.isCrouching())
+          (!IClientConfiguration.getInstance().getInvertPickBlockBehaviour().get() && player.isShiftKeyDown()) ||
+          (IClientConfiguration.getInstance().getInvertPickBlockBehaviour().get() && !player.isShiftKeyDown())
         )
         {
             return getBlockEntity(blockGetter, pos)

--- a/common/src/main/java/mod/chiselsandbits/item/ChiseledBlockItem.java
+++ b/common/src/main/java/mod/chiselsandbits/item/ChiseledBlockItem.java
@@ -113,7 +113,7 @@ public class ChiseledBlockItem extends BlockItem implements IChiseledBlockItem
     public InteractionResult place(@NotNull final BlockPlaceContext context)
     {
         final IAreaAccessor source = this.createItemStack(context.getItemInHand());
-        final IWorldAreaMutator areaMutator = context.getPlayer().isCrouching() ?
+        final IWorldAreaMutator areaMutator = context.getPlayer().isShiftKeyDown() ?
                                                 IMutatorFactory.getInstance().covering(
                                                   context.getLevel(),
                                                   context.getClickLocation(),

--- a/common/src/main/java/mod/chiselsandbits/item/SingleUsePatternItem.java
+++ b/common/src/main/java/mod/chiselsandbits/item/SingleUsePatternItem.java
@@ -85,7 +85,7 @@ public class SingleUsePatternItem extends Item implements IPatternItem
             if (!context.getPlayer().isCreative())
                 return InteractionResult.FAIL;
 
-            if (!context.getPlayer().isCrouching())
+            if (!context.getPlayer().isShiftKeyDown())
                 return InteractionResult.FAIL;
 
             final IWorldAreaMutator areaMutator = IMutatorFactory.getInstance().in(context.getLevel(), context.getClickedPos());

--- a/common/src/main/java/mod/chiselsandbits/logic/ScrollBasedModeChangeHandler.java
+++ b/common/src/main/java/mod/chiselsandbits/logic/ScrollBasedModeChangeHandler.java
@@ -14,7 +14,7 @@ public class ScrollBasedModeChangeHandler
 {
 
     public static boolean onScroll(final double scrollDelta) {
-        if (Minecraft.getInstance().player == null || !Minecraft.getInstance().player.isCrouching())
+        if (Minecraft.getInstance().player == null || !Minecraft.getInstance().player.isShiftKeyDown())
             return false;
 
         final ItemStack stack = ItemStackUtils.getModeItemStackFromPlayer(Minecraft.getInstance().player);

--- a/common/src/main/java/mod/chiselsandbits/pattern/placement/CarvePatternPlacementType.java
+++ b/common/src/main/java/mod/chiselsandbits/pattern/placement/CarvePatternPlacementType.java
@@ -64,7 +64,7 @@ public class CarvePatternPlacementType extends AbstractCustomRegistryEntry imple
     @Override
     public PlacementResult performPlacement(final IMultiStateSnapshot source, final BlockPlaceContext context, final boolean simulate)
     {
-        final Vec3 targetedPosition = context.getPlayer().isCrouching() ?
+        final Vec3 targetedPosition = context.getPlayer().isShiftKeyDown() ?
                                             context.getClickLocation()
                                             : Vec3.atLowerCornerOf(context.getClickedPos().offset(context.getClickedFace().getOpposite().getNormal()));
         final IWorldAreaMutator areaMutator =
@@ -141,7 +141,7 @@ public class CarvePatternPlacementType extends AbstractCustomRegistryEntry imple
     public Vec3 getTargetedPosition(
       final ItemStack heldStack, final Player player, final BlockHitResult blockRayTraceResult)
     {
-        if (player.isCrouching())
+        if (player.isShiftKeyDown())
         {
             return blockRayTraceResult.getLocation();
         }

--- a/common/src/main/java/mod/chiselsandbits/pattern/placement/ImposePatternPlacementType.java
+++ b/common/src/main/java/mod/chiselsandbits/pattern/placement/ImposePatternPlacementType.java
@@ -66,7 +66,7 @@ public class ImposePatternPlacementType extends AbstractCustomRegistryEntry impl
     @Override
     public PlacementResult performPlacement(final IMultiStateSnapshot source, final BlockPlaceContext context, final boolean simulate)
     {
-        final Vec3 targetedPosition = context.getPlayer().isCrouching() ?
+        final Vec3 targetedPosition = context.getPlayer().isShiftKeyDown() ?
                                             context.getClickLocation()
                                             : Vec3.atLowerCornerOf(context.getClickedPos().offset(context.getClickedFace().getOpposite().getNormal()));
         final IWorldAreaMutator areaMutator =
@@ -175,7 +175,7 @@ public class ImposePatternPlacementType extends AbstractCustomRegistryEntry impl
     public Vec3 getTargetedPosition(
       final ItemStack heldStack, final Player playerEntity, final BlockHitResult blockRayTraceResult)
     {
-        if (playerEntity.isCrouching())
+        if (playerEntity.isShiftKeyDown())
         {
             return blockRayTraceResult.getLocation();
         }

--- a/common/src/main/java/mod/chiselsandbits/pattern/placement/MergePatternPlacementType.java
+++ b/common/src/main/java/mod/chiselsandbits/pattern/placement/MergePatternPlacementType.java
@@ -65,7 +65,7 @@ public class MergePatternPlacementType extends AbstractCustomRegistryEntry imple
     @Override
     public PlacementResult performPlacement(final IMultiStateSnapshot source, final BlockPlaceContext context, final boolean simulate)
     {
-        final Vec3 targetedPosition = context.getPlayer().isCrouching() ?
+        final Vec3 targetedPosition = context.getPlayer().isShiftKeyDown() ?
                                             context.getClickLocation()
                                             : Vec3.atLowerCornerOf(context.getClickedPos().offset(context.getClickedFace().getOpposite().getNormal()));
         final IWorldAreaMutator areaMutator =
@@ -180,7 +180,7 @@ public class MergePatternPlacementType extends AbstractCustomRegistryEntry imple
     public Vec3 getTargetedPosition(
       final ItemStack heldStack, final Player player, final BlockHitResult blockHitResult)
     {
-        if (player.isCrouching())
+        if (player.isShiftKeyDown())
         {
             return blockHitResult.getLocation();
         }

--- a/common/src/main/java/mod/chiselsandbits/pattern/placement/PlacePatternPlacementType.java
+++ b/common/src/main/java/mod/chiselsandbits/pattern/placement/PlacePatternPlacementType.java
@@ -48,7 +48,7 @@ public class PlacePatternPlacementType extends AbstractCustomRegistryEntry imple
     public PlacementResult performPlacement(
       final IMultiStateSnapshot source, final BlockPlaceContext context, final boolean simulate)
     {
-        final Vec3 targetedPosition = context.getPlayer().isCrouching() ?
+        final Vec3 targetedPosition = context.getPlayer().isShiftKeyDown() ?
                                             context.getClickLocation()
                                             : Vec3.atLowerCornerOf(context.getClickedPos());
         final IWorldAreaMutator areaMutator =
@@ -117,7 +117,7 @@ public class PlacePatternPlacementType extends AbstractCustomRegistryEntry imple
     public Vec3 getTargetedPosition(
       final ItemStack heldStack, final Player playerEntity, final BlockHitResult blockRayTraceResult)
     {
-        if (playerEntity.isCrouching())
+        if (playerEntity.isShiftKeyDown())
         {
             return blockRayTraceResult.getLocation();
         }

--- a/common/src/main/java/mod/chiselsandbits/pattern/placement/RemovalPatternPlacementType.java
+++ b/common/src/main/java/mod/chiselsandbits/pattern/placement/RemovalPatternPlacementType.java
@@ -48,8 +48,8 @@ public class RemovalPatternPlacementType extends AbstractCustomRegistryEntry imp
     {
         final BlockPos targetedPosition = hitFace.getAxisDirection() == Direction.AxisDirection.NEGATIVE ? new BlockPos(targetedPoint) : new BlockPos(targetedPoint).offset(hitFace.getOpposite().getNormal());
         final VoxelShape targetingShape = BlockPosStreamProvider.getForRange(
-          player.isCrouching() ? targetedPoint : Vec3.atLowerCornerOf(targetedPosition) ,
-          player.isCrouching() ? targetedPoint.add(0.9999, 0.9999,0.9999): Vec3.atLowerCornerOf(targetedPosition)
+          player.isShiftKeyDown() ? targetedPoint : Vec3.atLowerCornerOf(targetedPosition) ,
+          player.isShiftKeyDown() ? targetedPoint.add(0.9999, 0.9999,0.9999): Vec3.atLowerCornerOf(targetedPosition)
         ).map(position -> player.level.getBlockState(position).getShape(
           player.level,
           position
@@ -60,7 +60,7 @@ public class RemovalPatternPlacementType extends AbstractCustomRegistryEntry imp
           )
         ).reduce(Shapes.empty(), (voxelShape, voxelShape2) -> Shapes.joinUnoptimized(voxelShape, voxelShape2, BooleanOp.OR)).optimize();
 
-        final Vec3 offSet = player.isCrouching() ?
+        final Vec3 offSet = player.isShiftKeyDown() ?
                                   new Vec3(
                                     targetedPoint.x() - targetedPosition.getX(),
                                     targetedPoint.y() - targetedPosition.getY(),
@@ -83,7 +83,7 @@ public class RemovalPatternPlacementType extends AbstractCustomRegistryEntry imp
     public PlacementResult performPlacement(
       final IMultiStateSnapshot source, final BlockPlaceContext context, final boolean simulate)
     {
-        final Vec3 targetedPosition = context.getPlayer().isCrouching() ?
+        final Vec3 targetedPosition = context.getPlayer().isShiftKeyDown() ?
                                             context.getClickLocation()
                                             : Vec3.atLowerCornerOf(context.getClickedPos().offset(context.getClickedFace().getOpposite().getNormal()));
         final IWorldAreaMutator areaMutator =


### PR DESCRIPTION
For the longest time, mods used the method in MCP mappings called `Entity#isSneaking` for user inputs. But when people move over to Mojang mappings, they see a number of similar methods, and the name `Entity#isCrouching` sound like it's the replacement.

However, `Entity#isCrouching` just detects whether an entity is in the crouching pose. This is almost never what a mod is actually trying to detect. It's `Entity#isShiftKeyDown` that's the Mojang mapped name for `Entity#isSneaking`, which returns whether the player is holding down whatever key they have bound to sneaking, just like it always did. This is almost always what a mod is trying to detect. Both methods are simultaneously synced and agree between client and server.

There is no downside to using `Entity#isShiftKeyDown`, yet there are two downsides to using `Entity#isCrouching`. The minor one is that if there is insufficient space to stand upright (an uncommon event), the player is forced into crouching and the method always returns true. The major downside is that if the player flying (a very common event; especially for creative mode building), the player is never crouching it always returns false.

This PR just replaces all calls to `Entity#isCrouching` with `Entity#isShiftKeyDown`.