### PR TITLE
Add place/break sounds and hit/destruction particles to chiseled blocks 

### DIFF
--- a/Platforms/Fabric/src/main/java/mod/chiselsandbits/fabric/mixin/client/ParticleEngineRenderPropertiesMixin.java
+++ b/Platforms/Fabric/src/main/java/mod/chiselsandbits/fabric/mixin/client/ParticleEngineRenderPropertiesMixin.java
@@ -1,0 +1,40 @@
+package mod.chiselsandbits.fabric.mixin.client;
+
+import mod.chiselsandbits.block.ChiseledBlock;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.particle.ParticleEngine;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.world.level.block.state.BlockState;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(ParticleEngine.class)
+public abstract class ParticleEngineRenderPropertiesMixin
+{
+
+    @Inject(method = "destroy", at = @At("HEAD"), cancellable = true)
+    public void onDestroy(BlockPos pos, BlockState state, final CallbackInfo callbackInfo) {
+        if (state.getBlock() instanceof ChiseledBlock chiseledBlock
+                && chiseledBlock.getRenderProperties().addDestroyEffects(
+                        state,
+                        Minecraft.getInstance().level,
+                        pos,
+                        Minecraft.getInstance().particleEngine))
+            callbackInfo.cancel();
+    }
+
+    @Inject(method = "crack", at = @At("HEAD"), cancellable = true)
+    public void onCrack(BlockPos pos, Direction direction, final CallbackInfo callbackInfo) {
+        BlockState state = Minecraft.getInstance().level.getBlockState(pos);
+        if (state.getBlock() instanceof ChiseledBlock chiseledBlock
+                && chiseledBlock.getRenderProperties().addHitEffects(
+                        state,
+                        Minecraft.getInstance().level,
+                        Minecraft.getInstance().hitResult,
+                        Minecraft.getInstance().particleEngine))
+            callbackInfo.cancel();
+    }
+}

--- a/Platforms/Forge/src/main/java/mod/chiselsandbits/forge/client/block/ForgeChiseledBlockRenderProperties.java
+++ b/Platforms/Forge/src/main/java/mod/chiselsandbits/forge/client/block/ForgeChiseledBlockRenderProperties.java
@@ -1,0 +1,8 @@
+package mod.chiselsandbits.forge.client.block;
+
+import mod.chiselsandbits.client.block.ChiseledBlockRenderProperties;
+import net.minecraftforge.client.IBlockRenderProperties;
+
+public class ForgeChiseledBlockRenderProperties extends ChiseledBlockRenderProperties implements IBlockRenderProperties
+{
+}

--- a/Platforms/Forge/src/main/java/mod/chiselsandbits/forge/platform/block/ForgeChiseledBlock.java
+++ b/Platforms/Forge/src/main/java/mod/chiselsandbits/forge/platform/block/ForgeChiseledBlock.java
@@ -1,0 +1,21 @@
+package mod.chiselsandbits.forge.platform.block;
+
+import mod.chiselsandbits.block.ChiseledBlock;
+import mod.chiselsandbits.forge.client.block.ForgeChiseledBlockRenderProperties;
+import net.minecraftforge.client.IBlockRenderProperties;
+
+import java.util.function.Consumer;
+
+public class ForgeChiseledBlock extends ChiseledBlock
+{
+    public ForgeChiseledBlock(Properties properties)
+    {
+        super(properties);
+    }
+
+    @Override
+    public void initializeClient(Consumer<IBlockRenderProperties> consumer)
+    {
+        consumer.accept(new ForgeChiseledBlockRenderProperties());
+    }
+}

--- a/common/src/main/java/mod/chiselsandbits/ChiselsAndBits.java
+++ b/common/src/main/java/mod/chiselsandbits/ChiselsAndBits.java
@@ -4,12 +4,16 @@ import mod.chiselsandbits.api.ChiselsAndBitsAPI;
 import mod.chiselsandbits.api.IChiselsAndBitsAPI;
 import mod.chiselsandbits.api.config.IChiselsAndBitsConfiguration;
 import mod.chiselsandbits.api.plugin.IChiselsAndBitsPlugin;
+import mod.chiselsandbits.block.ChiseledBlock;
 import mod.chiselsandbits.platforms.core.util.constants.Constants;
 import mod.chiselsandbits.config.ChiselsAndBitsConfiguration;
 import mod.chiselsandbits.network.NetworkChannel;
 import mod.chiselsandbits.plugin.PluginManger;
 import mod.chiselsandbits.registrars.*;
 import mod.chiselsandbits.utils.LanguageHandler;
+import net.minecraft.world.level.block.state.BlockBehaviour;
+
+import java.util.function.Function;
 
 public class ChiselsAndBits
 {
@@ -18,7 +22,7 @@ public class ChiselsAndBits
 
 	private final IChiselsAndBitsConfiguration configuration;
 
-	public ChiselsAndBits()
+	public ChiselsAndBits(Function<BlockBehaviour.Properties, ChiseledBlock> chiseledBlockFactory)
 	{
 	    instance = this;
         LanguageHandler.loadLangPath("assets/chiselsandbits/lang/%s.json");
@@ -27,7 +31,7 @@ public class ChiselsAndBits
         IChiselsAndBitsAPI.Holder.setInstance(ChiselsAndBitsAPI.getInstance());
 
         ModBlockEntityTypes.onModConstruction();
-        ModBlocks.onModConstruction();
+        ModBlocks.onModConstruction(chiseledBlockFactory);
         ModChiselModeGroups.onModConstruction();
         ModChiselModes.onModConstruction();
         ModContainerTypes.onModConstruction();

--- a/common/src/main/java/mod/chiselsandbits/client/block/ChiseledBlockRenderProperties.java
+++ b/common/src/main/java/mod/chiselsandbits/client/block/ChiseledBlockRenderProperties.java
@@ -29,7 +29,7 @@ public class ChiseledBlockRenderProperties
         if (!(target instanceof BlockHitResult blockTarget) || target.getType() == HitResult.Type.MISS)
             return false;
 
-        BlockState primaryState = getPrimaryState(level, blockTarget.getBlockPos());
+        final BlockState primaryState = getPrimaryState(level, blockTarget.getBlockPos());
         if (primaryState == null)
             return false;
 
@@ -38,7 +38,7 @@ public class ChiseledBlockRenderProperties
 
     public boolean addDestroyEffects(BlockState state, Level level, BlockPos pos, ParticleEngine engine)
     {
-        BlockState primaryState = getPrimaryState(level, pos);
+        final BlockState primaryState = getPrimaryState(level, pos);
         if (primaryState == null)
             return false;
 

--- a/common/src/main/java/mod/chiselsandbits/client/block/ChiseledBlockRenderProperties.java
+++ b/common/src/main/java/mod/chiselsandbits/client/block/ChiseledBlockRenderProperties.java
@@ -1,0 +1,48 @@
+package mod.chiselsandbits.client.block;
+
+import mod.chiselsandbits.api.block.entity.IMultiStateBlockEntity;
+import mod.chiselsandbits.utils.EffectUtils;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.particle.ParticleEngine;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.phys.BlockHitResult;
+import net.minecraft.world.phys.HitResult;
+import org.jetbrains.annotations.Nullable;
+
+public class ChiseledBlockRenderProperties
+{
+
+    @Nullable
+    private BlockState getPrimaryState(Level level, BlockPos pos) {
+        final BlockEntity blockEntity = level.getBlockEntity(pos);
+        if (!(blockEntity instanceof IMultiStateBlockEntity multiStateBlockEntity))
+            return null;
+
+        return multiStateBlockEntity.getStatistics().getPrimaryState().getBlockState();
+    }
+
+    public boolean addHitEffects(BlockState state, Level level, HitResult target, ParticleEngine engine)
+    {
+        if (!(target instanceof BlockHitResult blockTarget) || target.getType() == HitResult.Type.MISS)
+            return false;
+
+        BlockState primaryState = getPrimaryState(level, blockTarget.getBlockPos());
+        if (primaryState == null)
+            return false;
+
+        return EffectUtils.addHitEffects(level, blockTarget, primaryState, engine);
+    }
+
+    public boolean addDestroyEffects(BlockState state, Level level, BlockPos pos, ParticleEngine engine)
+    {
+        BlockState primaryState = getPrimaryState(level, pos);
+        if (primaryState == null)
+            return false;
+
+        EffectUtils.addBlockDestroyEffects(level, pos, primaryState, Minecraft.getInstance().particleEngine, level);
+        return true;
+    }
+}

--- a/common/src/main/java/mod/chiselsandbits/item/ChiseledBlockItem.java
+++ b/common/src/main/java/mod/chiselsandbits/item/ChiseledBlockItem.java
@@ -18,12 +18,15 @@ import mod.chiselsandbits.api.placement.PlacementResult;
 import mod.chiselsandbits.api.util.BlockStateUtils;
 import mod.chiselsandbits.api.util.HelpTextUtils;
 import mod.chiselsandbits.api.util.LocalStrings;
+import mod.chiselsandbits.block.ChiseledBlock;
 import mod.chiselsandbits.item.multistate.SingleBlockMultiStateItemStack;
 import mod.chiselsandbits.multistate.snapshot.SimpleSnapshot;
 import mod.chiselsandbits.platforms.core.util.constants.NbtConstants;
 import mod.chiselsandbits.registrars.ModModificationOperation;
+import net.minecraft.core.BlockPos;
 import net.minecraft.core.Vec3i;
 import net.minecraft.network.chat.Component;
+import net.minecraft.sounds.SoundSource;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.BlockItem;
@@ -32,6 +35,9 @@ import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.SoundType;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.gameevent.GameEvent;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.Vec3;
 import org.jetbrains.annotations.NotNull;
@@ -112,15 +118,22 @@ public class ChiseledBlockItem extends BlockItem implements IChiseledBlockItem
     @Override
     public InteractionResult place(@NotNull final BlockPlaceContext context)
     {
+        final Player player = context.getPlayer();
+        if (player == null)
+            return InteractionResult.FAIL;
+
+        final Level level = context.getLevel();
+        final BlockPos pos = context.getClickedPos();
+
         final IAreaAccessor source = this.createItemStack(context.getItemInHand());
-        final IWorldAreaMutator areaMutator = context.getPlayer().isShiftKeyDown() ?
+        final IWorldAreaMutator areaMutator = player.isShiftKeyDown() ?
                                                 IMutatorFactory.getInstance().covering(
-                                                  context.getLevel(),
+                                                  level,
                                                   context.getClickLocation(),
                                                   context.getClickLocation().add(1d, 1d, 1d)
                                                 )
                                                 :
-                                                  IMutatorFactory.getInstance().in(context.getLevel(), context.getClickedPos());
+                                                  IMutatorFactory.getInstance().in(level, pos);
         final IMultiStateSnapshot attemptTarget = areaMutator.createSnapshot();
 
         final boolean noCollisions = source.stream().sequential()
@@ -158,6 +171,13 @@ public class ChiseledBlockItem extends BlockItem implements IChiseledBlockItem
                 );
             }
 
+            if (getBlock() instanceof ChiseledBlock chiseledBlock)
+            {
+                level.gameEvent(player, GameEvent.BLOCK_PLACE, pos);
+                BlockState state = level.getBlockState(pos);
+                final SoundType soundtype = chiseledBlock.getSoundType(state, level, pos, player);
+                level.playSound(player, pos, soundtype.getPlaceSound(), SoundSource.BLOCKS, (soundtype.getVolume() + 1.0F) / 2.0F, soundtype.getPitch() * 0.8F);
+            }
 
             if (context.getPlayer() == null || !context.getPlayer().isCreative()) {
                 context.getItemInHand().shrink(1);

--- a/common/src/main/java/mod/chiselsandbits/item/ChiseledBlockItem.java
+++ b/common/src/main/java/mod/chiselsandbits/item/ChiseledBlockItem.java
@@ -174,7 +174,7 @@ public class ChiseledBlockItem extends BlockItem implements IChiseledBlockItem
             if (getBlock() instanceof ChiseledBlock chiseledBlock)
             {
                 level.gameEvent(player, GameEvent.BLOCK_PLACE, pos);
-                BlockState state = level.getBlockState(pos);
+                final BlockState state = level.getBlockState(pos);
                 final SoundType soundtype = chiseledBlock.getSoundType(state, level, pos, player);
                 level.playSound(player, pos, soundtype.getPlaceSound(), SoundSource.BLOCKS, (soundtype.getVolume() + 1.0F) / 2.0F, soundtype.getPitch() * 0.8F);
             }

--- a/common/src/main/java/mod/chiselsandbits/registrars/ModBlocks.java
+++ b/common/src/main/java/mod/chiselsandbits/registrars/ModBlocks.java
@@ -15,6 +15,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.Map;
+import java.util.function.Function;
 
 public final class ModBlocks
 {
@@ -80,7 +81,7 @@ public final class ModBlocks
         throw new IllegalStateException("Tried to initialize: ModBlocks but this is a Utility class.");
     }
 
-    public static void onModConstruction()
+    public static void onModConstruction(Function<BlockBehaviour.Properties, ChiseledBlock> chiseledBlockFactory)
     {
         MaterialManager.getInstance()
           .getKnownMaterials()
@@ -88,7 +89,7 @@ public final class ModBlocks
             material,
             BLOCK_REGISTRAR.register(
               "chiseled" + name,
-              () -> new ChiseledBlock(BlockBehaviour.Properties
+              () -> chiseledBlockFactory.apply(BlockBehaviour.Properties
                 .of(material)
                 .strength(1.5f, 6f)
                 .isRedstoneConductor((p_test_1_, p_test_2_, p_test_3_) -> false)

--- a/common/src/main/java/mod/chiselsandbits/utils/EffectUtils.java
+++ b/common/src/main/java/mod/chiselsandbits/utils/EffectUtils.java
@@ -32,14 +32,14 @@ public class EffectUtils
     {
         if (!primaryState.isAir())
         {
-            VoxelShape voxelshape = levelReader.getBlockState(pos).getShape(levelReader, pos);
+            final VoxelShape voxelshape = levelReader.getBlockState(pos).getShape(levelReader, pos);
             voxelshape.forAllBoxes((p_228348_3_, p_228348_5_, p_228348_7_, p_228348_9_, p_228348_11_, p_228348_13_) -> {
-                double d1 = Math.min(1.0D, p_228348_9_ - p_228348_3_);
-                double d2 = Math.min(1.0D, p_228348_11_ - p_228348_5_);
-                double d3 = Math.min(1.0D, p_228348_13_ - p_228348_7_);
-                int i = Math.max(2, Mth.ceil(d1 / 0.25D));
-                int j = Math.max(2, Mth.ceil(d2 / 0.25D));
-                int k = Math.max(2, Mth.ceil(d3 / 0.25D));
+                final double d1 = Math.min(1.0D, p_228348_9_ - p_228348_3_);
+                final double d2 = Math.min(1.0D, p_228348_11_ - p_228348_5_);
+                final double d3 = Math.min(1.0D, p_228348_13_ - p_228348_7_);
+                final int i = Math.max(2, Mth.ceil(d1 / 0.25D));
+                final int j = Math.max(2, Mth.ceil(d2 / 0.25D));
+                final int k = Math.max(2, Mth.ceil(d3 / 0.25D));
 
                 for (int l = 0; l < i; ++l)
                 {
@@ -47,12 +47,12 @@ public class EffectUtils
                     {
                         for (int j1 = 0; j1 < k; ++j1)
                         {
-                            double d4 = ((double) l + 0.5D) / (double) i;
-                            double d5 = ((double) i1 + 0.5D) / (double) j;
-                            double d6 = ((double) j1 + 0.5D) / (double) k;
-                            double d7 = d4 * d1 + p_228348_3_;
-                            double d8 = d5 * d2 + p_228348_5_;
-                            double d9 = d6 * d3 + p_228348_7_;
+                            final double d4 = ((double) l + 0.5D) / (double) i;
+                            final double d5 = ((double) i1 + 0.5D) / (double) j;
+                            final double d6 = ((double) j1 + 0.5D) / (double) k;
+                            final double d7 = d4 * d1 + p_228348_3_;
+                            final double d8 = d5 * d2 + p_228348_5_;
+                            final double d9 = d6 * d3 + p_228348_7_;
                             manager.add((new TerrainParticle((ClientLevel) renderingWorld,
                               (double) pos.getX() + d7,
                               (double) pos.getY() + d8,
@@ -83,7 +83,7 @@ public class EffectUtils
         final BlockPos pos = blockRayTraceResult.getBlockPos();
         final double boxOffset = 0.1;
 
-        AABB bb = world.getBlockState(pos).getShape(world, pos).bounds();
+        final AABB bb = world.getBlockState(pos).getShape(world, pos).bounds();
 
         double x = pos.getX() + RANDOM.nextDouble() * (bb.maxX - bb.minX - boxOffset * 2d) + boxOffset + bb.minX;
         double y = pos.getY() + RANDOM.nextDouble() * (bb.maxY - bb.minY - boxOffset * 2d) + boxOffset + bb.minY;

--- a/platforms/fabric/src/main/java/mod/chiselsandbits/fabric/FabricChiselsAndBitsMod.java
+++ b/platforms/fabric/src/main/java/mod/chiselsandbits/fabric/FabricChiselsAndBitsMod.java
@@ -2,6 +2,7 @@ package mod.chiselsandbits.fabric;
 
 import mod.chiselsandbits.ChiselsAndBits;
 import mod.chiselsandbits.api.item.click.ClickProcessingState;
+import mod.chiselsandbits.block.ChiseledBlock;
 import mod.chiselsandbits.fabric.integration.forge.ForgeTags;
 import mod.chiselsandbits.fabric.platform.FabricChiselsAndBitsPlatform;
 import mod.chiselsandbits.fabric.platform.server.FabricServerLifecycleManager;
@@ -33,7 +34,7 @@ public class FabricChiselsAndBitsMod implements ModInitializer {
         platform = FabricChiselsAndBitsPlatform.getInstance();
         IChiselsAndBitsPlatformCore.Holder.setInstance(platform);
 
-        instance = new ChiselsAndBits();
+        instance = new ChiselsAndBits(ChiseledBlock::new);
 
         setupEvents();
         ForgeTags.init();

--- a/platforms/fabric/src/main/resources/chiselsandbits.mixins.json
+++ b/platforms/fabric/src/main/resources/chiselsandbits.mixins.json
@@ -31,6 +31,7 @@
     "client.resources.PaintingTextureManagerConstructionHandler",
     "client.AbstractClientPlayerMixin",
     "client.CustomHeadLayerMixin",
+    "client.ParticleEngineRenderPropertiesMixin",
     "platform.client.multiplayer.MultiPlayerGameModeWorldlyBlockMixin",
     "platform.client.render.LevelRendererWorldlyBlockMixin",
     "platform.client.render.block.ModelBlockRendererWorldlyBlockMixin"

--- a/platforms/forge/src/main/java/mod/chiselsandbits/forge/ForgeChiselsAndBits.java
+++ b/platforms/forge/src/main/java/mod/chiselsandbits/forge/ForgeChiselsAndBits.java
@@ -2,7 +2,7 @@ package mod.chiselsandbits.forge;
 
 import mod.chiselsandbits.ChiselsAndBits;
 import mod.chiselsandbits.forge.platform.ForgeChiselsAndBitsPlatform;
-import mod.chiselsandbits.utils.LanguageHandler;
+import mod.chiselsandbits.forge.platform.block.ForgeChiseledBlock;
 import mod.chiselsandbits.platforms.core.IChiselsAndBitsPlatformCore;
 import mod.chiselsandbits.platforms.core.util.constants.Constants;
 import net.minecraftforge.fml.common.Mod;
@@ -18,7 +18,7 @@ public class ForgeChiselsAndBits
         platform = new ForgeChiselsAndBitsPlatform();
         IChiselsAndBitsPlatformCore.Holder.setInstance(platform);
 
-	    instance = new ChiselsAndBits();
+	    instance = new ChiselsAndBits(ForgeChiseledBlock::new);
 	}
 
     public static ChiselsAndBits getInstance()


### PR DESCRIPTION
This was simple on Forge, due to the `ParticleEngine` hooks it adds, but a version of those hooks needed to be added via mixins on Fabric for full implementation of sounds/particles.