### PR TITLE
Fix chiseled block model quad culling

### DIFF
--- a/common/src/main/java/mod/chiselsandbits/client/culling/MCCullTest.java
+++ b/common/src/main/java/mod/chiselsandbits/client/culling/MCCullTest.java
@@ -2,13 +2,11 @@ package mod.chiselsandbits.client.culling;
 
 import mod.chiselsandbits.api.blockinformation.BlockInformation;
 import net.minecraft.core.Direction;
-import net.minecraft.world.level.block.LiquidBlock;
-import net.minecraft.world.level.block.StainedGlassBlock;
 
 /**
- * Determine Culling using Block's Native Check.
+ * Determine Culling using Block's Native Checks.
  *
- * hardcode vanilla stained glass because that looks horrible.
+ * Simplified version of {@link net.minecraft.world.level.block.Block#shouldRenderFace Block.shouldRenderFace}
  */
 public class MCCullTest implements ICullTest
 {
@@ -22,26 +20,12 @@ public class MCCullTest implements ICullTest
 			return false;
 		}
 
-		if ( a.getBlockState().getBlock().getClass() == StainedGlassBlock.class && a.getBlockState().getBlock() == b.getBlockState().getBlock() )
-		{
-			return false;
-		}
-
-        if (a.getBlockState().getBlock() instanceof LiquidBlock && b.getBlockState().getBlock() instanceof LiquidBlock)
-        {
-            return !(a.getBlockState().getFluidState().getType().equals(b.getBlockState().getFluidState().getType()) &&
-              a.getVariant().equals(b.getVariant()));
-        }
-
-		if (a.isAir() && !b.isAir())
-		    return false;
-
-		if (b.isAir() && !a.isAir())
-		    return true;
-
 		try
 		{
-			return !a.getBlockState().skipRendering( b.getBlockState(), Direction.NORTH );
+			if (a.getBlockState().skipRendering( b.getBlockState(), Direction.NORTH ))
+				return false;
+
+			return !b.getBlockState().canOcclude();
 		}
 		catch ( final Throwable t )
 		{

--- a/common/src/main/java/mod/chiselsandbits/client/model/baked/chiseled/ChiselRenderType.java
+++ b/common/src/main/java/mod/chiselsandbits/client/model/baked/chiseled/ChiselRenderType.java
@@ -63,7 +63,7 @@ public enum ChiselRenderType
     public boolean isRequiredForRendering(
       final BlockInformation state )
     {
-        if (!this.type.isValidBlockState(state))
+        if (state.isAir() || !this.type.isValidBlockState(state))
             return false;
 
         if (this.type.isFluid()) {


### PR DESCRIPTION
This PR also causes `ChiselRenderType#isRequiredForRendering` to return false when passed air bits. By returning true, `ChiseledBlockBakedModel#processFaces` does alot of needless face processing and loading of `resultingFaces` with air `FaceRegion` lists. They go on to get needlessly merged in `mergeFaces`, only to be ignored during quad generation when `FaceManager#getCachedFace` always returns an empty `ModelQuadLayer` array.