### PR TITLE
Fix external chiseled block model quads reverting to un-culled state upon leaving the world and re-entering

### DIFF
--- a/Platforms/Fabric/src/main/java/mod/chiselsandbits/fabric/mixin/platform/client/render/block/ChiseledBlockModelUpdateMixin.java
+++ b/Platforms/Fabric/src/main/java/mod/chiselsandbits/fabric/mixin/platform/client/render/block/ChiseledBlockModelUpdateMixin.java
@@ -1,6 +1,6 @@
 package mod.chiselsandbits.fabric.mixin.platform.client.render.block;
 
-import mod.chiselsandbits.block.entities.ChiseledBlockEntity;
+import mod.chiselsandbits.client.logic.ChiseledBlockModelUpdateHandler;
 import net.minecraft.client.multiplayer.ClientChunkCache;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.FriendlyByteBuf;
@@ -9,7 +9,6 @@ import net.minecraft.world.level.chunk.LevelChunk;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
@@ -38,6 +37,6 @@ public abstract class ChiseledBlockModelUpdateMixin
             final LevelChunk levelChunk
     )
     {
-        ChiseledBlockEntity.updateAllModelDataInChunk(levelChunk);
+        ChiseledBlockModelUpdateHandler.updateAllModelDataInChunk(levelChunk);
     }
 }

--- a/Platforms/Fabric/src/main/java/mod/chiselsandbits/fabric/mixin/platform/client/render/block/ChiseledBlockModelUpdateMixin.java
+++ b/Platforms/Fabric/src/main/java/mod/chiselsandbits/fabric/mixin/platform/client/render/block/ChiseledBlockModelUpdateMixin.java
@@ -1,0 +1,43 @@
+package mod.chiselsandbits.fabric.mixin.platform.client.render.block;
+
+import mod.chiselsandbits.block.entities.ChiseledBlockEntity;
+import net.minecraft.client.multiplayer.ClientChunkCache;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.protocol.game.ClientboundLevelChunkPacketData;
+import net.minecraft.world.level.chunk.LevelChunk;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+
+import java.util.function.Consumer;
+
+@Mixin(ClientChunkCache.class)
+public abstract class ChiseledBlockModelUpdateMixin
+{
+
+    @Inject(
+            method = "replaceWithPacketData",
+            at = @At(
+                    value = "RETURN",
+                    ordinal = 1
+            ),
+            locals = LocalCapture.CAPTURE_FAILHARD
+    )
+    public void onReplaceWithPacketData(
+            final int i,
+            final int j,
+            final FriendlyByteBuf buf,
+            final CompoundTag tag,
+            final Consumer<ClientboundLevelChunkPacketData.BlockEntityTagOutput> tagOutputConsumer,
+            final CallbackInfoReturnable<LevelChunk> ci,
+            final int k,
+            final LevelChunk levelChunk
+    )
+    {
+        ChiseledBlockEntity.updateAllModelDataInChunk(levelChunk);
+    }
+}

--- a/Platforms/Forge/src/main/java/mod/chiselsandbits/forge/client/events/ChiseledBlockModelEventHandler.java
+++ b/Platforms/Forge/src/main/java/mod/chiselsandbits/forge/client/events/ChiseledBlockModelEventHandler.java
@@ -1,6 +1,6 @@
 package mod.chiselsandbits.forge.client.events;
 
-import mod.chiselsandbits.block.entities.ChiseledBlockEntity;
+import mod.chiselsandbits.client.logic.ChiseledBlockModelUpdateHandler;
 import mod.chiselsandbits.platforms.core.util.constants.Constants;
 import net.minecraft.world.level.chunk.LevelChunk;
 import net.minecraftforge.api.distmarker.Dist;
@@ -16,6 +16,6 @@ public class ChiseledBlockModelEventHandler
     public static void onChunkLoaded(final ChunkEvent.Load event)
     {
         if (event.getChunk() instanceof LevelChunk levelChunk)
-            ChiseledBlockEntity.updateAllModelDataInChunk(levelChunk);
+            ChiseledBlockModelUpdateHandler.updateAllModelDataInChunk(levelChunk);
     }
 }

--- a/Platforms/Forge/src/main/java/mod/chiselsandbits/forge/client/events/ChiseledBlockModelEventHandler.java
+++ b/Platforms/Forge/src/main/java/mod/chiselsandbits/forge/client/events/ChiseledBlockModelEventHandler.java
@@ -1,0 +1,21 @@
+package mod.chiselsandbits.forge.client.events;
+
+import mod.chiselsandbits.block.entities.ChiseledBlockEntity;
+import mod.chiselsandbits.platforms.core.util.constants.Constants;
+import net.minecraft.world.level.chunk.LevelChunk;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.event.world.ChunkEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+
+@Mod.EventBusSubscriber(modid = Constants.MOD_ID, value = Dist.CLIENT, bus = Mod.EventBusSubscriber.Bus.FORGE)
+public class ChiseledBlockModelEventHandler
+{
+
+    @SubscribeEvent
+    public static void onChunkLoaded(final ChunkEvent.Load event)
+    {
+        if (event.getChunk() instanceof LevelChunk levelChunk)
+            ChiseledBlockEntity.updateAllModelDataInChunk(levelChunk);
+    }
+}

--- a/common/src/main/java/mod/chiselsandbits/block/ChiseledBlock.java
+++ b/common/src/main/java/mod/chiselsandbits/block/ChiseledBlock.java
@@ -26,7 +26,6 @@ import mod.chiselsandbits.api.util.SingleBlockWorldReader;
 import mod.chiselsandbits.api.voxelshape.IVoxelShapeManager;
 import mod.chiselsandbits.block.entities.ChiseledBlockEntity;
 import mod.chiselsandbits.client.block.ChiseledBlockRenderProperties;
-import mod.chiselsandbits.client.model.data.ChiseledBlockModelDataManager;
 import mod.chiselsandbits.clipboard.CreativeClipboardUtils;
 import mod.chiselsandbits.network.packets.NeighborBlockUpdatedPacket;
 import mod.chiselsandbits.platforms.core.block.IBlockWithWorldlyProperties;
@@ -461,10 +460,13 @@ public class ChiseledBlock extends Block implements IMultiStateBlock, SimpleWate
       final @NotNull BlockPos otherPosition,
       final boolean update)
     {
-        final BlockEntity tileEntity = level.getBlockEntity(position);
-        if (level.isClientSide() && tileEntity instanceof ChiseledBlockEntity) {
-            ChiseledBlockModelDataManager.getInstance().updateModelData((ChiseledBlockEntity) tileEntity);
-        } else if (!level.isClientSide() && tileEntity instanceof ChiseledBlockEntity) {
+        if (!(level.getBlockEntity(position) instanceof ChiseledBlockEntity chiseledBlockEntity))
+            return;
+
+        if (level.isClientSide())
+            chiseledBlockEntity.updateModelData();
+        else
+        {
             ChiselsAndBits.getInstance().getNetworkChannel().sendToTrackingChunk(
                 new NeighborBlockUpdatedPacket(position, otherPosition),
                 level.getChunkAt(position)

--- a/common/src/main/java/mod/chiselsandbits/block/entities/ChiseledBlockEntity.java
+++ b/common/src/main/java/mod/chiselsandbits/block/entities/ChiseledBlockEntity.java
@@ -120,17 +120,6 @@ public class ChiseledBlockEntity extends BlockEntity implements
             updateModelData();
     }
 
-    public static void updateAllModelDataInChunk(LevelChunk chunk)
-    {
-        chunk.getBlockEntities()
-                .values()
-                .forEach(blockEntity ->
-                {
-                    if (blockEntity instanceof ChiseledBlockEntity chiseledBlockEntity)
-                        chiseledBlockEntity.updateModelData();
-                });
-    }
-
     @Override
     public void setLevel(@Nullable final Level level)
     {

--- a/common/src/main/java/mod/chiselsandbits/block/entities/ChiseledBlockEntity.java
+++ b/common/src/main/java/mod/chiselsandbits/block/entities/ChiseledBlockEntity.java
@@ -61,6 +61,7 @@ import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.SnowLayerBlock;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.chunk.LevelChunk;
 import net.minecraft.world.level.chunk.LevelChunkSection;
 import net.minecraft.world.level.lighting.LayerLightEngine;
 import net.minecraft.world.phys.AABB;
@@ -106,6 +107,28 @@ public class ChiseledBlockEntity extends BlockEntity implements
                           .withLegacy(new LegacyGZIPStorageBasedStorageHandler())
                           .with(new LZ4StorageBasedStorageHandler())
                           .buildMultiThreaded();
+    }
+
+    public void updateModelData()
+    {
+        ChiseledBlockModelDataManager.getInstance().updateModelData(this);
+    }
+
+    private void updateModelDataIfInLoadedChunk()
+    {
+        if (level != null && level.isClientSide() && level.isLoaded(getBlockPos()))
+            updateModelData();
+    }
+
+    public static void updateAllModelDataInChunk(LevelChunk chunk)
+    {
+        chunk.getBlockEntities()
+                .values()
+                .forEach(blockEntity ->
+                {
+                    if (blockEntity instanceof ChiseledBlockEntity chiseledBlockEntity)
+                        chiseledBlockEntity.updateModelData();
+                });
     }
 
     @Override
@@ -248,7 +271,7 @@ public class ChiseledBlockEntity extends BlockEntity implements
     {
         this.storageEngine.deserializeNBT(nbt);
         this.lastTag = nbt;
-        ChiseledBlockModelDataManager.getInstance().updateModelData(this);
+        updateModelDataIfInLoadedChunk();
     }
 
     @Override
@@ -363,7 +386,7 @@ public class ChiseledBlockEntity extends BlockEntity implements
     {
         storage.deserializeFrom(packetBuffer);
         mutableStatistics.deserializeFrom(packetBuffer);
-        ChiseledBlockModelDataManager.getInstance().updateModelData(this);
+        updateModelDataIfInLoadedChunk();
     }
 
     /**

--- a/common/src/main/java/mod/chiselsandbits/client/logic/ChiseledBlockModelUpdateHandler.java
+++ b/common/src/main/java/mod/chiselsandbits/client/logic/ChiseledBlockModelUpdateHandler.java
@@ -1,0 +1,20 @@
+package mod.chiselsandbits.client.logic;
+
+import mod.chiselsandbits.block.entities.ChiseledBlockEntity;
+import net.minecraft.world.level.chunk.LevelChunk;
+
+public class ChiseledBlockModelUpdateHandler
+{
+
+    public static void updateAllModelDataInChunk(LevelChunk chunk)
+    {
+        chunk.getBlockEntities()
+                .values()
+                .forEach(blockEntity ->
+                {
+                    if (blockEntity instanceof ChiseledBlockEntity chiseledBlockEntity)
+                        chiseledBlockEntity.updateModelData();
+                });
+    }
+
+}

--- a/platforms/fabric/src/main/resources/chiselsandbits.mixins.json
+++ b/platforms/fabric/src/main/resources/chiselsandbits.mixins.json
@@ -34,7 +34,8 @@
     "client.ParticleEngineRenderPropertiesMixin",
     "platform.client.multiplayer.MultiPlayerGameModeWorldlyBlockMixin",
     "platform.client.render.LevelRendererWorldlyBlockMixin",
-    "platform.client.render.block.ModelBlockRendererWorldlyBlockMixin"
+    "platform.client.render.block.ModelBlockRendererWorldlyBlockMixin",
+    "platform.client.render.block.ChiseledBlockModelUpdateMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
In addition to doing so when neighbors change, chiseled block models were being reloaded upon deserialization from NBT. This is fine when the chunk is loaded, but when the chunk first loads, the blocks deserialize before thier neighbors are in place, so external faces don't cull.

This PR preserves the current reloading upon deserialization when the chunk is loaded, but delays it until after it's loaded when blocks deserialize before the chunk loads. Just as it was with the particle/sound PR, the proper hook is used when on Forge, but a special case of the Forge hook is implemented via a mixin when on Fabric.

With this PR, #943 is fully fixed.