### PR TITLE
Fix ghost block model z-fighting and inconsistent quad visibility

### DIFF
--- a/api/src/main/java/mod/chiselsandbits/api/item/chiseled/IChiseledBlockItem.java
+++ b/api/src/main/java/mod/chiselsandbits/api/item/chiseled/IChiseledBlockItem.java
@@ -48,10 +48,4 @@ public interface IChiseledBlockItem extends IMultiStateItem, IPlacementPreviewPr
     {
         return false;
     }
-
-    @Override
-    default boolean ignoreDepth(ItemStack heldStack)
-    {
-        return overridesOccupiedBits(heldStack);
-    }
 }

--- a/api/src/main/java/mod/chiselsandbits/api/item/pattern/IPatternItem.java
+++ b/api/src/main/java/mod/chiselsandbits/api/item/pattern/IPatternItem.java
@@ -65,10 +65,4 @@ public interface IPatternItem extends IMultiStateItem, ISupportsSealing, IWithMo
     {
         return getMode(heldStack).overridesOccupiedBits(heldStack);
     }
-
-    @Override
-    default boolean ignoreDepth(ItemStack heldStack)
-    {
-        return overridesOccupiedBits(heldStack);
-    }
 }

--- a/api/src/main/java/mod/chiselsandbits/api/item/wireframe/IWireframeProvidingItem.java
+++ b/api/src/main/java/mod/chiselsandbits/api/item/wireframe/IWireframeProvidingItem.java
@@ -58,6 +58,12 @@ public interface IWireframeProvidingItem
 
     /**
      * Returns whether to effectively ignore the depth buffer and render in front of everything
+     *
+     * @param heldStack The stack to get depth logic for.
+     * @return Whether depth is effectively ignored.
      */
-    boolean ignoreDepth(ItemStack heldStack);
+    default boolean ignoreDepth(ItemStack heldStack)
+    {
+        return true;
+    }
 }

--- a/api/src/main/java/mod/chiselsandbits/api/placement/IPlacementPreviewProvidingItem.java
+++ b/api/src/main/java/mod/chiselsandbits/api/placement/IPlacementPreviewProvidingItem.java
@@ -1,7 +1,34 @@
 package mod.chiselsandbits.api.placement;
 
 import mod.chiselsandbits.api.item.wireframe.IWireframeProvidingItem;
+import net.minecraft.world.item.ItemStack;
 
 public interface IPlacementPreviewProvidingItem extends IWireframeProvidingItem, IPlaceable, IPlacementProperties
 {
+
+    /**
+     * Returns whether to effectively ignore the depth buffer and render in front of everything for a given placement result.
+     *
+     * @param heldStack The stack to get depth logic for.
+     * @param placementResult The placement result to get depth logic for.
+     * @return Whether depth is effectively ignored.
+     */
+    default boolean ignoreDepthForPlacement(
+            ItemStack heldStack,
+            PlacementResult placementResult
+    )
+    {
+        return !placementResult.isSuccess() || ignoreDepth(heldStack);
+    }
+
+    /**
+     * Returns whether to effectively ignore the depth buffer and render in front of everything
+     *
+     * @param heldStack The stack to get depth logic for.
+     * @return Whether depth is effectively ignored.
+     */
+    default boolean ignoreDepth(ItemStack heldStack)
+    {
+        return overridesOccupiedBits(heldStack);
+    }
 }

--- a/common/src/main/java/mod/chiselsandbits/client/logic/MultiStateBlockPreviewRenderHandler.java
+++ b/common/src/main/java/mod/chiselsandbits/client/logic/MultiStateBlockPreviewRenderHandler.java
@@ -49,11 +49,20 @@ public class MultiStateBlockPreviewRenderHandler
                 targetedRenderPos.z % bitSize + (targetedRenderPos.z < 0 ? bitSize : 0)
         );
 
-        final boolean ignoreDepth = wireframeItem.ignoreDepth(heldStack);
-        final boolean forceWireframe = !(heldStack.getItem() instanceof IPlacementPreviewProvidingItem);
-        final PlacementResult placementResult = heldStack.getItem() instanceof IPlacementPreviewProvidingItem placementPreviewItem
-                ? placementPreviewItem.getPlacementResult(heldStack, playerEntity, blockRayTraceResult)
-                : PlacementResult.failure(wireframeItem.getWireFrameColor(heldStack, playerEntity, blockRayTraceResult));
+        final PlacementResult placementResult;
+        final boolean ignoreDepth, forceWireframe;
+        if (heldStack.getItem() instanceof IPlacementPreviewProvidingItem placementPreviewItem)
+        {
+            placementResult = placementPreviewItem.getPlacementResult(heldStack, playerEntity, blockRayTraceResult);
+            ignoreDepth = placementPreviewItem.ignoreDepthForPlacement(heldStack, placementResult);
+            forceWireframe = false;
+        }
+        else
+        {
+            placementResult = PlacementResult.failure(wireframeItem.getWireFrameColor(heldStack, playerEntity, blockRayTraceResult));
+            ignoreDepth = wireframeItem.ignoreDepth(heldStack);
+            forceWireframe = true;
+        }
 
         final IClientConfiguration clientConfig = IClientConfiguration.getInstance();
         final PlacementPreviewRenderMode success = clientConfig.getSuccessfulPlacementRenderMode().get();


### PR DESCRIPTION
The reason non-placement pattern modes ignore the depth buffer is because their area of modification normally intersects solid bits. The same reasoning applies to failed placement of chiseled blocks and to the non-fitting failure of the placement mode of patterns. In attempting to prevent colored ghost block model z-fighting, I realized that by ignoring the depth buffer when rendering failed placement, consistency is increased, failure is made more obvious, and the z-fighting problem is solved.

This PR also further optimizes colored ghost block model rendering by setting up directional arrays for shaded colors and transformed normals once per render call, rather than additionally doing so once per inner quad.