### PR TITLE
Cull Test Improvements for complex neighbors

### DIFF
--- a/common/src/main/java/mod/chiselsandbits/client/culling/ICullTest.java
+++ b/common/src/main/java/mod/chiselsandbits/client/culling/ICullTest.java
@@ -2,7 +2,6 @@ package mod.chiselsandbits.client.culling;
 
 import mod.chiselsandbits.api.blockinformation.BlockInformation;
 import mod.chiselsandbits.api.multistate.accessor.IStateEntryInfo;
-import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 
 public interface ICullTest
@@ -10,6 +9,5 @@ public interface ICullTest
     boolean isVisible(
       IStateEntryInfo mySpot,
       BlockInformation secondPost,
-      BlockPos secondBlockPos,
       Direction dir);
 }

--- a/common/src/main/java/mod/chiselsandbits/client/culling/ICullTest.java
+++ b/common/src/main/java/mod/chiselsandbits/client/culling/ICullTest.java
@@ -1,13 +1,15 @@
 package mod.chiselsandbits.client.culling;
 
 import mod.chiselsandbits.api.blockinformation.BlockInformation;
-import net.minecraft.world.level.block.state.BlockState;
+import mod.chiselsandbits.api.multistate.accessor.IStateEntryInfo;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
 
 public interface ICullTest
 {
-
-	boolean isVisible(
-			BlockInformation mySpot,
-      BlockInformation secondSpot );
-
+    boolean isVisible(
+      IStateEntryInfo mySpot,
+      BlockInformation secondPost,
+      BlockPos secondBlockPos,
+      Direction dir);
 }

--- a/common/src/main/java/mod/chiselsandbits/client/culling/MCCullTest.java
+++ b/common/src/main/java/mod/chiselsandbits/client/culling/MCCullTest.java
@@ -2,6 +2,7 @@ package mod.chiselsandbits.client.culling;
 
 import mod.chiselsandbits.api.blockinformation.BlockInformation;
 import mod.chiselsandbits.api.multistate.accessor.IStateEntryInfo;
+import mod.chiselsandbits.api.multistate.accessor.world.IInWorldStateEntryInfo;
 import net.minecraft.client.Minecraft;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
@@ -20,7 +21,6 @@ public class MCCullTest implements ICullTest
     public boolean isVisible(
       final IStateEntryInfo aInfo,
       final BlockInformation b,
-      final BlockPos bPos,
       final Direction dir)
     {
         final BlockInformation a = aInfo.getBlockInformation();
@@ -32,21 +32,28 @@ public class MCCullTest implements ICullTest
         {
             return false;
         }
+        if(!(aInfo instanceof IInWorldStateEntryInfo aBlockEntity))
+        {
+            // Shouldn't happen?  Maybe if someone's picked up a Chiseled block or another mod is rendering it?
+            return true;
+        }
         if(b.getBlockState().canOcclude() && Minecraft.getInstance().level != null)
         {
+            final BlockPos aPos = new BlockPos(aBlockEntity.getBlockPos());
+            final BlockPos bPos = aPos.relative(dir);
             // This is largely a reimplementation of Block#shouldRenderFace without the caching and more readily used in ChiseledBlockBakedModel's context.
             if (a.getBlockState().skipRendering(b.getBlockState(), dir))
             {
                 return false;
             }
             // There's already some awkward caching underneath getFaceOcclusion, so this call shouldn't be too expensive in bulk.
-            final VoxelShape bShape = b.getBlockState().getFaceOcclusionShape(Minecraft.getInstance().level, bPos, dir);
+            final VoxelShape bShape = b.getBlockState().getFaceOcclusionShape(Minecraft.getInstance().level, aPos, dir);
             if (bShape.isEmpty())
             {
                 // If there's no geometry on a face that's touching the block in question, nearly always want to render that 'side'.
                 return true;
             }
-            final VoxelShape aShape = a.getBlockState().getFaceOcclusionShape(Minecraft.getInstance().level, new BlockPos(aInfo.getCenterPoint()), dir);
+            final VoxelShape aShape = a.getBlockState().getFaceOcclusionShape(Minecraft.getInstance().level, bPos, dir);
             return Shapes.joinIsNotEmpty(aShape, bShape, BooleanOp.ONLY_FIRST);
             // Vanilla implements an Object2ByteLinkedOpenHashmap to cache these checks, albeit a fairly small (2048)-sized one.
             // Not sure if it makes sense to do for this implementation, since variations are likely to be much higher and duplicates much, much lower.

--- a/common/src/main/java/mod/chiselsandbits/client/culling/MCCullTest.java
+++ b/common/src/main/java/mod/chiselsandbits/client/culling/MCCullTest.java
@@ -1,7 +1,13 @@
 package mod.chiselsandbits.client.culling;
 
 import mod.chiselsandbits.api.blockinformation.BlockInformation;
+import mod.chiselsandbits.api.multistate.accessor.IStateEntryInfo;
+import net.minecraft.client.Minecraft;
+import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.world.phys.shapes.BooleanOp;
+import net.minecraft.world.phys.shapes.Shapes;
+import net.minecraft.world.phys.shapes.VoxelShape;
 
 /**
  * Determine Culling using Block's Native Checks.
@@ -10,26 +16,41 @@ import net.minecraft.core.Direction;
  */
 public class MCCullTest implements ICullTest
 {
-	@Override
-	public boolean isVisible(
-			final BlockInformation a,
-			final BlockInformation b )
-	{
-		if ( a == b )
-		{
-			return false;
-		}
-
-		try
-		{
-			if (a.getBlockState().skipRendering( b.getBlockState(), Direction.NORTH ))
-				return false;
-
-			return !b.getBlockState().canOcclude();
-		}
-		catch ( final Throwable t )
-		{
-		    return false;
-		}
-	}
+    @Override
+    public boolean isVisible(
+      final IStateEntryInfo aInfo,
+      final BlockInformation b,
+      final BlockPos bPos,
+      final Direction dir)
+    {
+        final BlockInformation a = aInfo.getBlockInformation();
+        if(a == b)
+        {
+            return false;
+        }
+        if(a.getBlockState().skipRendering(b.getBlockState(), Direction.NORTH))
+        {
+            return false;
+        }
+        if(b.getBlockState().canOcclude() && Minecraft.getInstance().level != null)
+        {
+            // This is largely a reimplementation of Block#shouldRenderFace without the caching and more readily used in ChiseledBlockBakedModel's context.
+            if (a.getBlockState().skipRendering(b.getBlockState(), dir))
+            {
+                return false;
+            }
+            // There's already some awkward caching underneath getFaceOcclusion, so this call shouldn't be too expensive in bulk.
+            final VoxelShape bShape = b.getBlockState().getFaceOcclusionShape(Minecraft.getInstance().level, bPos, dir);
+            if (bShape.isEmpty())
+            {
+                // If there's no geometry on a face that's touching the block in question, nearly always want to render that 'side'.
+                return true;
+            }
+            final VoxelShape aShape = a.getBlockState().getFaceOcclusionShape(Minecraft.getInstance().level, new BlockPos(aInfo.getCenterPoint()), dir);
+            return Shapes.joinIsNotEmpty(aShape, bShape, BooleanOp.ONLY_FIRST);
+            // Vanilla implements an Object2ByteLinkedOpenHashmap to cache these checks, albeit a fairly small (2048)-sized one.
+            // Not sure if it makes sense to do for this implementation, since variations are likely to be much higher and duplicates much, much lower.
+        }
+        return true;
+    }
 }

--- a/common/src/main/java/mod/chiselsandbits/client/model/baked/chiseled/ChiseledBlockBakedModel.java
+++ b/common/src/main/java/mod/chiselsandbits/client/model/baked/chiseled/ChiseledBlockBakedModel.java
@@ -25,7 +25,6 @@ import net.minecraft.client.renderer.texture.MissingTextureAtlasSprite;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.client.resources.model.BakedModel;
 import net.minecraft.client.resources.model.ModelState;
-import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.inventory.InventoryMenu;
@@ -425,13 +424,13 @@ public class ChiseledBlockBakedModel extends BaseBakedBlockModel {
                         final BlockInformation externalNeighborState = neighborStateSupplier.apply(offsetTarget);
 
                         return Optional.of(externalNeighborState)
-                                .map(neighborState -> test.isVisible(stateEntryInfo, neighborState, new BlockPos(offsetTarget), facing))
+                                .map(neighborState -> test.isVisible(stateEntryInfo, neighborState, facing))
                                 .orElseGet(() -> !stateEntryInfo.getBlockInformation().isAir());
                     }
 
                     return blob.getInAreaTarget(offsetTarget)
                             .map(IStateEntryInfo::getBlockInformation)
-                            .map(neighborState -> test.isVisible(stateEntryInfo, neighborState, new BlockPos(offsetTarget), facing))
+                            .map(neighborState -> test.isVisible(stateEntryInfo, neighborState, facing))
                             .orElseGet(() -> !stateEntryInfo.getBlockInformation().isAir());
                 })
                 .map(stateEntryInfo -> {

--- a/common/src/main/java/mod/chiselsandbits/client/model/baked/chiseled/ChiseledBlockBakedModel.java
+++ b/common/src/main/java/mod/chiselsandbits/client/model/baked/chiseled/ChiseledBlockBakedModel.java
@@ -25,6 +25,7 @@ import net.minecraft.client.renderer.texture.MissingTextureAtlasSprite;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.client.resources.model.BakedModel;
 import net.minecraft.client.resources.model.ModelState;
+import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.inventory.InventoryMenu;
@@ -424,13 +425,13 @@ public class ChiseledBlockBakedModel extends BaseBakedBlockModel {
                         final BlockInformation externalNeighborState = neighborStateSupplier.apply(offsetTarget);
 
                         return Optional.of(externalNeighborState)
-                                .map(neighborState -> test.isVisible(stateEntryInfo.getBlockInformation(), neighborState))
+                                .map(neighborState -> test.isVisible(stateEntryInfo, neighborState, new BlockPos(offsetTarget), facing))
                                 .orElseGet(() -> !stateEntryInfo.getBlockInformation().isAir());
                     }
 
                     return blob.getInAreaTarget(offsetTarget)
                             .map(IStateEntryInfo::getBlockInformation)
-                            .map(neighborState -> test.isVisible(stateEntryInfo.getBlockInformation(), neighborState))
+                            .map(neighborState -> test.isVisible(stateEntryInfo, neighborState, new BlockPos(offsetTarget), facing))
                             .orElseGet(() -> !stateEntryInfo.getBlockInformation().isAir());
                 })
                 .map(stateEntryInfo -> {

--- a/common/src/main/resources/assets/chiselsandbits/lang/en_us.json
+++ b/common/src/main/resources/assets/chiselsandbits/lang/en_us.json
@@ -294,6 +294,7 @@
   "mod.chiselsandbits.keys.key.undo": "Undo last chiseling operation",
   "mod.chiselsandbits.keys.key.redo": "Redo last undone chiseling operation",
   "mod.chiselsandbits.keys.key.zoom": "Zoom with monocle",
+  "mod.chiselsandbits.keys.key.reset-caches": "Reset Chisels&Bits caches",
   "mod.chiselsandbits.test": "Placeholder text during development",
   "mod.chiselsandbits.pattern.modification.group.mirror": "Mirror",
   "mod.chiselsandbits.pattern.modification.group.rotate": "Rotate",


### PR DESCRIPTION
- fixes #983, #985, a variety of related cases.

Improves the Cull Test behaviors for non-solid occluding neighbors, generally complex shapes or those that don't properly consider themselves light-transparent but are see-through.  This is mostly pulling more out of Block#shouldRenderFace, but a) in an easier-to-use format given buildFaceRegion's existing format, and b) bypasses some of the caching that makes sense in other contexts, but is likely to get stomped by even a small amount of Chiseled blocks.
~~Not entirely happy with the Vec3->BlockPos requirements, but the performance impact should be pretty minimal.~~

Adds a missing keybind translation text key.