### PR TITLE
Fix integer overflow when bit bag stack size is too large

### DIFF
--- a/common/src/main/java/mod/chiselsandbits/inventory/bit/AbstractBitInventory.java
+++ b/common/src/main/java/mod/chiselsandbits/inventory/bit/AbstractBitInventory.java
@@ -169,10 +169,10 @@ public abstract class AbstractBitInventory implements IBitInventory
     @Override
     public int getMaxInsertAmount(final BlockInformation blockInformation)
     {
-        return IntStream.range(0, getInventorySize())
+        final long maxInsertAmount = IntStream.range(0, getInventorySize())
                  .mapToObj(this::getItem)
                  .filter(stack -> stack.getItem() instanceof IBitItem || stack.getItem() instanceof IBitInventoryItem || stack.isEmpty())
-                 .mapToInt(stack -> {
+                 .mapToLong(stack -> {
                      if (stack.isEmpty())
                          return getMaxBitsForSlot();
 
@@ -191,6 +191,8 @@ public abstract class AbstractBitInventory implements IBitInventory
                      return 0;
                  })
                  .sum();
+
+        return (int)Math.min(maxInsertAmount, Integer.MAX_VALUE);
     }
 
     /**


### PR DESCRIPTION
This PR fixes an issue where configuring a large stack size for bit bags would cause an integer overflow. This would cause bits to spawn on the ground (or be deleted, depending on config) instead of being placed in the bag as expected.