### PR TITLE
Issue with C&B and create contraptions

### DIFF
--- a/forge/src/main/java/mod/chiselsandbits/forge/compat/create/CreateCandBPlugin.java
+++ b/forge/src/main/java/mod/chiselsandbits/forge/compat/create/CreateCandBPlugin.java
@@ -18,18 +18,19 @@ public class CreateCandBPlugin implements IChiselsAndBitsPlugin {
     public void onInitialize() {
         ModBlocks.MATERIAL_TO_BLOCK_CONVERSIONS.values().forEach(blockRegistration -> {
             AllMovementBehaviours.registerBehaviour(blockRegistration.get(), new ChiseledBlockMovementBehaviour());
-            BlockMovementChecks.registerMovementAllowedCheck((state, world, pos) -> {
-                if (state.getBlock() instanceof ChiseledBlock)
-                    return BlockMovementChecks.CheckResult.SUCCESS;
+        });
+        AllMovementBehaviours.registerBehaviour(ModBlocks.CHISELED_BLOCK.get(), new ChiseledBlockMovementBehaviour());
+        BlockMovementChecks.registerMovementAllowedCheck((state, world, pos) -> {
+            if (state.getBlock() instanceof ChiseledBlock)
+                return BlockMovementChecks.CheckResult.SUCCESS;
 
-                return BlockMovementChecks.CheckResult.PASS;
-            });
-            BlockMovementChecks.registerMovementNecessaryCheck((state, world, pos) -> {
-                if (state.getBlock() instanceof ChiseledBlock)
-                    return BlockMovementChecks.CheckResult.SUCCESS;
+            return BlockMovementChecks.CheckResult.PASS;
+        });
+        BlockMovementChecks.registerMovementNecessaryCheck((state, world, pos) -> {
+            if (state.getBlock() instanceof ChiseledBlock)
+                return BlockMovementChecks.CheckResult.SUCCESS;
 
-                return BlockMovementChecks.CheckResult.PASS;
-            });
+            return BlockMovementChecks.CheckResult.PASS;
         });
     }
 }


### PR DESCRIPTION
The C&B create compat is currently broken, as the blocks don't render in contraptions. When debugging this issue I noticed that the contraption behaviour is added to all the `MATERIAL_TO_BLOCK_CONVERSIONS` blocks. I am not 100% aware of what these are or where they are used, but these do not exist in-game (or are not detected by create). Instead, create detects the general `chiselled` block. A fix then seems to be registering this general block to create in the `registerMovementAllowedCheck`, which makes the block render in a contraption.