### PR TITLE
Adds the ability to convert bits into blocks straight out of the bit bag

### DIFF
--- a/api/src/main/java/mod/chiselsandbits/api/inventory/bit/IBitInventoryItemStack.java
+++ b/api/src/main/java/mod/chiselsandbits/api/inventory/bit/IBitInventoryItemStack.java
@@ -2,6 +2,7 @@ package mod.chiselsandbits.api.inventory.bit;
 
 import mod.chiselsandbits.api.blockinformation.IBlockInformation;
 import net.minecraft.world.Container;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.network.chat.Component;
 
@@ -46,4 +47,9 @@ public interface IBitInventoryItemStack extends IBitInventory, Container
      * Sorts the bit inventory.
      */
     void sort();
+
+    /**
+     * Converts the inventory into blocks
+     */
+    void convert(Player player);
 }

--- a/api/src/main/java/mod/chiselsandbits/api/util/LocalStrings.java
+++ b/api/src/main/java/mod/chiselsandbits/api/util/LocalStrings.java
@@ -116,6 +116,7 @@ public enum LocalStrings
     ReallyTrash("help.reallytrash"),
     ReallyTrashItem("help.reallytrash_blank"),
     TrashInvalidItem("help.trash.invalid"),
+    Convert("help.convert"),
 
     PositivePatternReplace("positivepatternmode.replace"),
     PositivePatternAdditive("positivepatternmode.additive"),

--- a/core/src/main/java/mod/chiselsandbits/client/screens/BitBagScreen.java
+++ b/core/src/main/java/mod/chiselsandbits/client/screens/BitBagScreen.java
@@ -11,6 +11,7 @@ import mod.chiselsandbits.container.BagContainer;
 import mod.chiselsandbits.inventory.wrapping.WrappingInventory;
 import mod.chiselsandbits.network.packets.BagGuiPacket;
 import mod.chiselsandbits.network.packets.ClearBagGuiPacket;
+import mod.chiselsandbits.network.packets.ConvertBagGuiPacket;
 import mod.chiselsandbits.network.packets.SortBagGuiPacket;
 import mod.chiselsandbits.registrars.ModItems;
 import net.minecraft.client.Minecraft;
@@ -37,6 +38,7 @@ public class BitBagScreen extends AbstractContainerScreen<BagContainer> {
     boolean dontThrow = false;
     private GuiIconButton trashBtn;
     private GuiIconButton sortBtn;
+    private GuiIconButton convertBtn;
     private Slot hoveredBitSlot = null;
 
     public BitBagScreen(
@@ -75,6 +77,15 @@ public class BitBagScreen extends AbstractContainerScreen<BagContainer> {
                     packet.execute(Minecraft.getInstance().player);
                 },
                 Tooltip.create(LocalStrings.Sort.getText())));
+
+        convertBtn = addRenderableWidget(new GuiIconButton(leftPos - 20, topPos + 42, LocalStrings.Convert.getText(), IconManager.getInstance().getPlaceIcon(),
+                button -> {
+                    final ConvertBagGuiPacket packet = new ConvertBagGuiPacket();
+                    ChiselsAndBits.getInstance().getNetworkChannel().sendToServer(packet);
+                    packet.execute(Minecraft.getInstance().player);
+                },
+                Tooltip.create(LocalStrings.Convert.getText())
+                ));
     }
 
     BagContainer getBagContainer() {

--- a/core/src/main/java/mod/chiselsandbits/container/BagContainer.java
+++ b/core/src/main/java/mod/chiselsandbits/container/BagContainer.java
@@ -370,4 +370,10 @@ public class BagContainer extends AbstractContainerMenu
         bagInv.sort();
         transferState(this);
     }
+
+    public void convert(Player player)
+    {
+        bagInv.convert(player);
+        transferState(this);
+    }
 }

--- a/core/src/main/java/mod/chiselsandbits/inventory/bit/SlottedBitInventoryItemStack.java
+++ b/core/src/main/java/mod/chiselsandbits/inventory/bit/SlottedBitInventoryItemStack.java
@@ -95,11 +95,11 @@ public class SlottedBitInventoryItemStack extends SlottedBitInventory implements
             }
 
             // Give player items for each 4096 bits they have (full block) 16^3
-            while (count >= 4096) {
+            while (count >= IServerConfiguration.getInstance().getBitSize().get().getBitsPerBlock()) {
                 // Give the block to the player
                 ItemStack block = new ItemStack(e.getKey().getBlockState().getBlock().asItem());
                 if (player.getInventory().add(block)) {
-                    count -= 4096;
+                    count -= IServerConfiguration.getInstance().getBitSize().get().getBitsPerBlock();
                 } else {
                     // The player has run out of space!
                     break;

--- a/core/src/main/java/mod/chiselsandbits/inventory/bit/SlottedBitInventoryItemStack.java
+++ b/core/src/main/java/mod/chiselsandbits/inventory/bit/SlottedBitInventoryItemStack.java
@@ -70,6 +70,55 @@ public class SlottedBitInventoryItemStack extends SlottedBitInventory implements
             }
         }
     }
+    @Override
+    public void convert(Player player) {
+        // Get counts of all the bits present in the bag and clear it.
+        final Map<IBlockInformation, Integer> contentMap = Maps.newHashMap();
+        this.slotMap.values().forEach(bitSlot -> {
+                    contentMap.putIfAbsent(bitSlot.getBlockInformation(), 0);
+                    contentMap.compute(bitSlot.getBlockInformation(), (s, c) -> (c == null ? 0 : c) + bitSlot.getCount());
+                }
+        );
+        this.slotMap.clear();
+
+
+
+        List<Map.Entry<IBlockInformation, Integer>> toSort = new ArrayList<>(contentMap.entrySet());
+        toSort.sort(Map.Entry.<IBlockInformation, Integer>comparingByValue().reversed());
+
+        int slotIndex = 0;
+        for (Map.Entry<IBlockInformation, Integer> e : toSort)
+        {
+            int count = e.getValue();
+            if (count == 0) {
+                continue;
+            }
+
+            // Give player items for each 4096 bits they have (full block) 16^3
+            while (count >= 4096) {
+                // Give the block to the player
+                ItemStack block = new ItemStack(e.getKey().getBlockState().getBlock().asItem());
+                if (player.getInventory().add(block)) {
+                    count -= 4096;
+                } else {
+                    // The player has run out of space!
+                    break;
+                }
+            }
+            // Sort the remaining bits into stacks.
+            while (count > IServerConfiguration.getInstance().getBagStackSize().get() && count > 0) {
+                this.slotMap.put(slotIndex, new BitSlot(e.getKey(), IServerConfiguration.getInstance().getBagStackSize().get()));
+                slotIndex++;
+                count -= IServerConfiguration.getInstance().getBagStackSize().get();
+            }
+
+            if (count > 0) {
+                this.slotMap.put(slotIndex, new BitSlot(e.getKey(), count));
+                slotIndex++;
+            }
+        }
+
+    }
 
     @Override
     public void sort()

--- a/core/src/main/java/mod/chiselsandbits/network/NetworkChannel.java
+++ b/core/src/main/java/mod/chiselsandbits/network/NetworkChannel.java
@@ -52,6 +52,7 @@ public class NetworkChannel
         registerMessage(index++, ClearBagGuiPacket.class, ClearBagGuiPacket::new);
         registerMessage(index++, OpenBagGuiPacket.class, OpenBagGuiPacket::new);
         registerMessage(index++, SortBagGuiPacket.class, SortBagGuiPacket::new);
+        registerMessage(index++, ConvertBagGuiPacket.class, ConvertBagGuiPacket::new);
         registerMessage(index++, MeasurementUpdatedPacket.class, MeasurementUpdatedPacket::new);
         registerMessage(index++, MeasurementsUpdatedPacket.class, MeasurementsUpdatedPacket::new);
         registerMessage(index++, MeasurementsResetPacket.class, MeasurementsResetPacket::new);

--- a/core/src/main/java/mod/chiselsandbits/network/packets/ConvertBagGuiPacket.java
+++ b/core/src/main/java/mod/chiselsandbits/network/packets/ConvertBagGuiPacket.java
@@ -1,0 +1,40 @@
+package mod.chiselsandbits.network.packets;
+
+import mod.chiselsandbits.container.BagContainer;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.player.Player;
+
+public final class ConvertBagGuiPacket extends ModPacket {
+
+    public  ConvertBagGuiPacket(FriendlyByteBuf buffer) {
+        readPayload(buffer);
+    }
+
+    public ConvertBagGuiPacket() {
+
+    }
+    @Override
+    public void writePayload(FriendlyByteBuf buffer) {
+
+    }
+
+    @Override
+    public void readPayload(FriendlyByteBuf buffer) {
+
+    }
+
+    @Override
+    public void server(
+            final ServerPlayer player)
+    {
+        execute(player);
+    }
+
+    public void execute(final Player player) {
+        if (player.containerMenu instanceof BagContainer)
+        {
+            ((BagContainer) player.containerMenu).convert(player);
+        }
+    }
+}

--- a/core/src/main/resources/assets/chiselsandbits/lang/en_us.json
+++ b/core/src/main/resources/assets/chiselsandbits/lang/en_us.json
@@ -198,6 +198,7 @@
   "mod.chiselsandbits.help.rightalt": "Right Alt",
   "mod.chiselsandbits.help.trash": "Delete Bag Contents, Hold Item to filter.",
   "mod.chiselsandbits.help.sort": "Condense and Combine",
+  "mod.chiselsandbits.help.convert": "Combine bits into full blocks",
   "mod.chiselsandbits.help.trashitem": "Delete only %s",
   "mod.chiselsandbits.help.reallytrash": "Click again to confirm deletion of all",
   "mod.chiselsandbits.help.reallytrash_blank": "Click again to confirm deletion of %s",
@@ -398,5 +399,6 @@
   "mod.chiselsandbits.patterns.import.failed.file-not-found": "Could not read the pattern, the file could not be found.",
   "mod.chiselsandbits.patterns.import.failed.invalid-chisel-data": "Could not read the pattern, the chisel data is invalid.",
   "mod.chiselsandbits.patterns.import.failed.unknown-version": "Could not read the pattern, the version is unknown.",
-  "mod.chiselsandbits.patterns.import.invoked-from-the-server": "Could not read the pattern, this command can only be invoked from the client."
+  "mod.chiselsandbits.patterns.import.invoked-from-the-server": "Could not read the pattern, this command can only be invoked from the client.",
+  "chiselsandbits.bitbag.contents.enum.entry": "s"
 }


### PR DESCRIPTION
This pull request adds the ability for bit bags to convert 4096 bits of a given type into their respective block.

Example:
![2024-01-20_14-23](https://github.com/ChiselsAndBits/Chisels-and-Bits/assets/59463043/6ce864e4-2361-408c-807e-03a1b1e48747)
![2024-01-20_14-23_1](https://github.com/ChiselsAndBits/Chisels-and-Bits/assets/59463043/106c83c6-bf42-4a8d-8bca-16f91ee4d4fb)

I found it quite annoying to having to choose either to place bits as blocks in order to recover the blocks I've amassed or to delete everything, so this fixes that.