### PR TITLE
Wrap the super method, since fabric cannot find it anymore

### DIFF
--- a/core/src/main/java/mod/chiselsandbits/block/entities/ChiseledBlockEntity.java
+++ b/core/src/main/java/mod/chiselsandbits/block/entities/ChiseledBlockEntity.java
@@ -106,6 +106,11 @@ public class ChiseledBlockEntity extends BlockEntity implements
     }
 
     @NotNull
+    public BlockPos getBlockPos() {
+        return super.getBlockPos();
+    }
+
+    @NotNull
     private static Executor createDefaultExecutor() {
         return DistExecutor.unsafeRunForDist(
                 () -> Minecraft::getInstance,


### PR DESCRIPTION
As far as I can tell, this is the only remaining breaking issue with latest fabric@1.20.4