### PR TITLE
fix world won't be loaded after placing ChiseledBlock

### DIFF
--- a/fabric/src/main/java/mod/chiselsandbits/fabric/mixin/MixinChiseledBlockEntity.java
+++ b/fabric/src/main/java/mod/chiselsandbits/fabric/mixin/MixinChiseledBlockEntity.java
@@ -1,0 +1,18 @@
+package mod.chiselsandbits.fabric.mixin;
+
+import com.communi.suggestu.scena.core.entity.block.IBlockEntityPositionManager;
+import mod.chiselsandbits.block.entities.ChiseledBlockEntity;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(ChiseledBlockEntity.class)
+public abstract class MixinChiseledBlockEntity {
+
+    @Redirect(method = "setLevel", at = @At(value = "INVOKE", target = "Lcom/communi/suggestu/scena/core/entity/block/IBlockEntityPositionManager;add(Lnet/minecraft/world/level/block/entity/BlockEntity;)V"))
+    private void chiselsandbits$disable(IBlockEntityPositionManager instance, BlockEntity blockEntity){
+        // IBlockEntityPositionManager#add causes deadlock on fabric
+        // So ignoring IBlockEntityPositionManager#add call
+    }
+}

--- a/fabric/src/main/java/mod/chiselsandbits/fabric/mixin/MixinLevelChunk.java
+++ b/fabric/src/main/java/mod/chiselsandbits/fabric/mixin/MixinLevelChunk.java
@@ -1,0 +1,24 @@
+package mod.chiselsandbits.fabric.mixin;
+
+import com.communi.suggestu.scena.fabric.platform.entity.IFabricBlockEntityPositionHolder;
+import mod.chiselsandbits.block.entities.ChiseledBlockEntity;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.chunk.LevelChunk;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(LevelChunk.class)
+public abstract class MixinLevelChunk {
+
+    // Fix https://github.com/ChiselsAndBits/Chisels-and-Bits/issues/1216
+    @Inject(method = "setBlockEntity", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/block/entity/BlockEntity;setLevel(Lnet/minecraft/world/level/Level;)V"))
+    private void mod$manuallyAddToHolder(BlockEntity blockEntity, CallbackInfo ci){
+        if(! (blockEntity instanceof ChiseledBlockEntity))
+            return;
+
+        IFabricBlockEntityPositionHolder holder = (IFabricBlockEntityPositionHolder) this;
+        holder.scena$add(blockEntity.getClass(), blockEntity.getBlockPos());
+    }
+}

--- a/fabric/src/main/resources/chiselsandbits.mixins.json
+++ b/fabric/src/main/resources/chiselsandbits.mixins.json
@@ -1,9 +1,11 @@
 {
   "required": true,
   "minVersion": "0.8",
-  "package": "@package@.fabric.mixin",
+  "package": "mod.chiselsandbits.fabric.mixin",
   "compatibilityLevel": "JAVA_16",
   "mixins": [
+    "MixinLevelChunk",
+    "MixinChiseledBlockEntity"
   ],
   "client": [
   ],


### PR DESCRIPTION
As described in https://github.com/ChiselsAndBits/Chisels-and-Bits/issues/1216, `IBlockEntityPositionManager.getInstance().add(this)` causes deadlock, which consequently getting stuck in 100% of world load.

It is commonly known that it only occurs on fabric, so we need to use mixin to simply disabling IBlockEntityPositionManager#add call and manually adding block entity to IFabricBlockEntityPositionHolder. 