### PR TITLE
Fix ignore RenderType when generating Faces and baking Model

### DIFF
--- a/api/src/main/java/mod/chiselsandbits/api/blockinformation/IBlockInformation.java
+++ b/api/src/main/java/mod/chiselsandbits/api/blockinformation/IBlockInformation.java
@@ -32,4 +32,6 @@ public interface IBlockInformation extends INBTSerializable<CompoundTag>, IPacke
     boolean isFluid();
 
     boolean isAir();
+
+    boolean isSeeThrough();
 }

--- a/core/src/main/java/mod/chiselsandbits/blockinformation/BlockInformation.java
+++ b/core/src/main/java/mod/chiselsandbits/blockinformation/BlockInformation.java
@@ -8,6 +8,8 @@ import mod.chiselsandbits.api.util.constants.NbtConstants;
 import mod.chiselsandbits.api.variant.state.IStateVariant;
 import mod.chiselsandbits.api.variant.state.IStateVariantManager;
 import mod.chiselsandbits.stateinfo.additional.StateVariantManager;
+import net.minecraft.client.renderer.ItemBlockRenderTypes;
+import net.minecraft.client.renderer.RenderType;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.world.level.block.Blocks;
@@ -126,6 +128,11 @@ public final class BlockInformation implements IBlockInformation {
     @Override
     public boolean isAir() {
         return getBlockState().isAir();
+    }
+
+    @Override
+    public boolean isSeeThrough() {
+        return isAir() || isFluid() || !ItemBlockRenderTypes.getChunkRenderType(getBlockState()).equals(RenderType.solid());
     }
 
     @Override

--- a/core/src/main/java/mod/chiselsandbits/client/model/baked/chiseled/ChiseledBlockBakedModelManager.java
+++ b/core/src/main/java/mod/chiselsandbits/client/model/baked/chiseled/ChiseledBlockBakedModelManager.java
@@ -105,6 +105,7 @@ public class ChiseledBlockBakedModelManager {
                                     primaryState,
                                     chiselRenderType,
                                     accessor,
+                                    blockNeighborhood,
                                     primaryStateRenderSeed
                             );
                         }

--- a/core/src/main/java/mod/chiselsandbits/client/model/meshing/GreedyMeshBuilder.java
+++ b/core/src/main/java/mod/chiselsandbits/client/model/meshing/GreedyMeshBuilder.java
@@ -46,30 +46,30 @@ public class GreedyMeshBuilder {
         }
         final MaterialProcessor materialProcessor = new MaterialProcessor();
         
-        final boolean RENDERTYPE_SOLID = chiselRenderType.layer.equals(RenderType.solid());
-        final int BITS_PER_BLOCK_SIDE = StateEntrySize.current().getBitsPerBlockSide();
-        final int BITS_PER_BLOCK_SIDE_P = BITS_PER_BLOCK_SIDE + 2;
-        final int BITS_PER_BLOCK_SIDE_P2 = BITS_PER_BLOCK_SIDE_P * BITS_PER_BLOCK_SIDE_P;
+        final boolean renderTypeSolid = chiselRenderType.layer.equals(RenderType.solid());
+        final int bitsPerBlockSide = StateEntrySize.current().getBitsPerBlockSide();
+        final int bitsPerBlockSideP = bitsPerBlockSide + 2;
+        final int bitsPerBlockSideP2 = bitsPerBlockSideP * bitsPerBlockSideP;
 
         final ArrayList<int[]> materialMaskCols = new ArrayList<>();
-        materialMaskCols.add(0, new int[3 * BITS_PER_BLOCK_SIDE_P2]);
+        materialMaskCols.add(0, new int[3 * bitsPerBlockSideP2]);
 
-        for (int x = 0; x < BITS_PER_BLOCK_SIDE_P; x++) {
-            for (int y = 0; y < BITS_PER_BLOCK_SIDE_P; y++) {
-                for (int z = 0; z < BITS_PER_BLOCK_SIDE_P; z++) {
+        for (int x = 0; x < bitsPerBlockSideP; x++) {
+            for (int y = 0; y < bitsPerBlockSideP; y++) {
+                for (int z = 0; z < bitsPerBlockSideP; z++) {
                     if (!materialData.getMaterial(x - 1, y - 1, z - 1).isSeeThrough()) {
-                        materialMaskCols.get(0)[x + (z * BITS_PER_BLOCK_SIDE_P)] |= (1 << y);
-                        materialMaskCols.get(0)[x + (y * BITS_PER_BLOCK_SIDE_P) + BITS_PER_BLOCK_SIDE_P2] |= (1 << z);
-                        materialMaskCols.get(0)[y + (z * BITS_PER_BLOCK_SIDE_P) + (BITS_PER_BLOCK_SIDE_P2 * 2)] |= (1 << x);
+                        materialMaskCols.get(0)[x + (z * bitsPerBlockSideP)] |= (1 << y);
+                        materialMaskCols.get(0)[x + (y * bitsPerBlockSideP) + bitsPerBlockSideP2] |= (1 << z);
+                        materialMaskCols.get(0)[y + (z * bitsPerBlockSideP) + (bitsPerBlockSideP2 * 2)] |= (1 << x);
                     }
-                    if (!RENDERTYPE_SOLID) {
+                    if (!renderTypeSolid) {
                         int materialIndex = materialProcessor.getMaterialIndex(x - 1, y - 1, z - 1);
                         if (materialIndex != 0) {
                             while (materialIndex >= materialMaskCols.size())
-                                materialMaskCols.add(new int[3 * BITS_PER_BLOCK_SIDE_P2]);
-                            materialMaskCols.get(materialIndex)[x + (z * BITS_PER_BLOCK_SIDE_P)] |= (1 << y);
-                            materialMaskCols.get(materialIndex)[x + (y * BITS_PER_BLOCK_SIDE_P) + BITS_PER_BLOCK_SIDE_P2] |= (1 << z);
-                            materialMaskCols.get(materialIndex)[y + (z * BITS_PER_BLOCK_SIDE_P) + (BITS_PER_BLOCK_SIDE_P2 * 2)] |= (1 << x);
+                                materialMaskCols.add(new int[3 * bitsPerBlockSideP2]);
+                            materialMaskCols.get(materialIndex)[x + (z * bitsPerBlockSideP)] |= (1 << y);
+                            materialMaskCols.get(materialIndex)[x + (y * bitsPerBlockSideP) + bitsPerBlockSideP2] |= (1 << z);
+                            materialMaskCols.get(materialIndex)[y + (z * bitsPerBlockSideP) + (bitsPerBlockSideP2 * 2)] |= (1 << x);
                         }
                     }
                 }
@@ -78,25 +78,25 @@ public class GreedyMeshBuilder {
 
         List<HashMap<Integer, HashMap<Integer, int[]>>> faceData = new ArrayList<>(6);
 
-        if (RENDERTYPE_SOLID) {
-            int[] faceMaskCols = new int[6 * BITS_PER_BLOCK_SIDE_P2];
+        if (renderTypeSolid) {
+            int[] faceMaskCols = new int[6 * bitsPerBlockSideP2];
 
             for (int axis = 0; axis < 3; axis++) {
-                for (int i = 0; i < BITS_PER_BLOCK_SIDE_P2; i++) {
-                    int col = materialMaskCols.get(0)[i + (BITS_PER_BLOCK_SIDE_P2 * axis)];
-                    faceMaskCols[i + (BITS_PER_BLOCK_SIDE_P2 * axis * 2)] = col & ~(col << 1);
-                    faceMaskCols[i + (BITS_PER_BLOCK_SIDE_P2 * ((axis * 2) + 1))] = col & ~(col >> 1);
+                for (int i = 0; i < bitsPerBlockSideP2; i++) {
+                    int col = materialMaskCols.get(0)[i + (bitsPerBlockSideP2 * axis)];
+                    faceMaskCols[i + (bitsPerBlockSideP2 * axis * 2)] = col & ~(col << 1);
+                    faceMaskCols[i + (bitsPerBlockSideP2 * ((axis * 2) + 1))] = col & ~(col >> 1);
                 }
             }
 
             for (int axis = 0; axis < 6; axis++) {
                 faceData.add(new HashMap<>());
-                for (int x = 0; x < BITS_PER_BLOCK_SIDE; x++) {
-                    for (int z = 0; z < BITS_PER_BLOCK_SIDE; z++) {
-                        int colIndex = 1 + x + ((z + 1) * BITS_PER_BLOCK_SIDE_P) + BITS_PER_BLOCK_SIDE_P2 * axis;
+                for (int x = 0; x < bitsPerBlockSide; x++) {
+                    for (int z = 0; z < bitsPerBlockSide; z++) {
+                        int colIndex = 1 + x + ((z + 1) * bitsPerBlockSideP) + bitsPerBlockSideP2 * axis;
 
                         int col = faceMaskCols[colIndex] >> 1;
-                        col &= ~(1 << BITS_PER_BLOCK_SIDE);
+                        col &= ~(1 << bitsPerBlockSide);
 
                         while (col != 0) {
                             int y = Integer.numberOfTrailingZeros(col);
@@ -110,34 +110,34 @@ public class GreedyMeshBuilder {
 
                             faceData.get(axis)
                                     .computeIfAbsent(bitMaterial, k -> new HashMap<>())
-                                    .computeIfAbsent(y, k -> new int[BITS_PER_BLOCK_SIDE])[x] |= 1 << z;
+                                    .computeIfAbsent(y, k -> new int[bitsPerBlockSide])[x] |= 1 << z;
                         }
                     }
                 }
             }
         }else {
             final ArrayList<int[]> faceColMasks = new ArrayList<>();
-            materialMaskCols.forEach((material) -> faceColMasks.add(new int[6 * BITS_PER_BLOCK_SIDE_P2]));
+            materialMaskCols.forEach((material) -> faceColMasks.add(new int[6 * bitsPerBlockSideP2]));
 
             for (int axis = 0; axis < 3; axis++) {
-                for (int i = 0; i < BITS_PER_BLOCK_SIDE_P2; i++) {
-                    int col = materialMaskCols.get(0)[i + (BITS_PER_BLOCK_SIDE_P2 * axis)];
+                for (int i = 0; i < bitsPerBlockSideP2; i++) {
+                    int col = materialMaskCols.get(0)[i + (bitsPerBlockSideP2 * axis)];
                     for (int material = 1; material < faceColMasks.size(); material++) {
-                        int materialCol = materialMaskCols.get(material)[i + (BITS_PER_BLOCK_SIDE_P2 * axis)];
-                        faceColMasks.get(material)[i + (BITS_PER_BLOCK_SIDE_P2 * axis * 2)] = materialCol & ~((materialCol | col) << 1);
-                        faceColMasks.get(material)[i + (BITS_PER_BLOCK_SIDE_P2 * ((axis * 2) + 1))] = materialCol & ~((materialCol | col) >> 1);
+                        int materialCol = materialMaskCols.get(material)[i + (bitsPerBlockSideP2 * axis)];
+                        faceColMasks.get(material)[i + (bitsPerBlockSideP2 * axis * 2)] = materialCol & ~((materialCol | col) << 1);
+                        faceColMasks.get(material)[i + (bitsPerBlockSideP2 * ((axis * 2) + 1))] = materialCol & ~((materialCol | col) >> 1);
                     }
                 }
             }
 
             for (int axis = 0; axis < 6; axis++) {
                 faceData.add(new HashMap<>());
-                for (int x = 0; x < BITS_PER_BLOCK_SIDE; x++) {
-                    for (int z = 0; z < BITS_PER_BLOCK_SIDE; z++) {
-                        int colIndex = 1 + x + ((z + 1) * BITS_PER_BLOCK_SIDE_P) + BITS_PER_BLOCK_SIDE_P2 * axis;
+                for (int x = 0; x < bitsPerBlockSide; x++) {
+                    for (int z = 0; z < bitsPerBlockSide; z++) {
+                        int colIndex = 1 + x + ((z + 1) * bitsPerBlockSideP) + bitsPerBlockSideP2 * axis;
                         for (int material = 1; material < faceColMasks.size(); material++) {
                             int col = faceColMasks.get(material)[colIndex] >> 1;
-                            col &= ~(1 << BITS_PER_BLOCK_SIDE);
+                            col &= ~(1 << bitsPerBlockSide);
 
                             while (col != 0) {
                                 int y = Integer.numberOfTrailingZeros(col);
@@ -145,7 +145,7 @@ public class GreedyMeshBuilder {
 
                                 faceData.get(axis)
                                         .computeIfAbsent(material, k -> new HashMap<>())
-                                        .computeIfAbsent(y, k -> new int[BITS_PER_BLOCK_SIDE])[x] |= 1 << z;
+                                        .computeIfAbsent(y, k -> new int[bitsPerBlockSide])[x] |= 1 << z;
                             }
                         }
                     }
@@ -156,7 +156,7 @@ public class GreedyMeshBuilder {
         for (int axis = 0; axis < faceData.size(); axis++) {
             Direction faceDirection = Direction.values()[axis];
             faceData.get(axis).forEach((material, axisFaces) -> axisFaces.forEach(
-                    (axisPos, plane) -> faces.addAll(greedyMeshBinaryPlane(plane, materials.get(material - 1), faceDirection, axisPos, BITS_PER_BLOCK_SIDE))
+                    (axisPos, plane) -> faces.addAll(greedyMeshBinaryPlane(plane, materials.get(material - 1), faceDirection, axisPos, bitsPerBlockSide))
             ));
         }
         return faces.toArray(new GreedyMeshFace[0]);

--- a/core/src/main/java/mod/chiselsandbits/client/model/meshing/GreedyMeshBuilder.java
+++ b/core/src/main/java/mod/chiselsandbits/client/model/meshing/GreedyMeshBuilder.java
@@ -1,21 +1,20 @@
 package mod.chiselsandbits.client.model.meshing;
 
-import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
-import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import mod.chiselsandbits.api.blockinformation.IBlockInformation;
 import mod.chiselsandbits.api.multistate.StateEntrySize;
+import mod.chiselsandbits.client.model.baked.chiseled.ChiselRenderType;
+import net.minecraft.client.renderer.RenderType;
 import net.minecraft.core.Direction;
 import org.jetbrains.annotations.NotNull;
 import org.joml.Vector3f;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 
 public class GreedyMeshBuilder {
-
-    private static final int DIMENSIONS = 3;
 
     private GreedyMeshBuilder() {
         throw new IllegalStateException("Cannot instantiate utility class");
@@ -26,172 +25,192 @@ public class GreedyMeshBuilder {
         IBlockInformation getMaterial(int x, int y, int z);
     }
 
-    public static GreedyMeshFace[] buildMesh(MaterialProvider data) {
+    public static GreedyMeshFace[] buildMesh(MaterialProvider materialData, ChiselRenderType chiselRenderType) {
         final List<GreedyMeshFace> faces = new ArrayList<>();
-        final int sizePerDimension = StateEntrySize.current().getBitsPerBlockSide();
-
         final Object2IntMap<IBlockInformation> indexByMaterial = new Object2IntOpenHashMap<>();
-        final Int2ObjectMap<IBlockInformation> materialByIndex = new Int2ObjectOpenHashMap<>();
-        final int[] mask = new int[sizePerDimension * sizePerDimension]; // The mask is used to keep track of which faces have been added to the mesh.
+        final ArrayList<IBlockInformation> materials = new ArrayList<>();
 
         class MaterialProcessor {
             final int getMaterialIndex(int x, int y, int z) {
-                final IBlockInformation blockInformation = data.getMaterial(x, y, z);
+                final IBlockInformation blockInformation = materialData.getMaterial(x, y, z);
 
-                if (blockInformation.isAir())
+                if (!chiselRenderType.isRequiredForRendering(blockInformation))
                     return 0;
 
                 return indexByMaterial.computeIfAbsent(blockInformation, k -> {
                     int index = indexByMaterial.size() + 1;
-                    materialByIndex.put(index, blockInformation);
+                    materials.add(blockInformation);
                     return index;
                 });
             }
         }
-
         final MaterialProcessor materialProcessor = new MaterialProcessor();
+        
+        final boolean RENDERTYPE_SOLID = chiselRenderType.layer.equals(RenderType.solid());
+        final int BITS_PER_BLOCK_SIDE = StateEntrySize.current().getBitsPerBlockSide();
+        final int BITS_PER_BLOCK_SIDE_P = BITS_PER_BLOCK_SIDE + 2;
+        final int BITS_PER_BLOCK_SIDE_P2 = BITS_PER_BLOCK_SIDE_P * BITS_PER_BLOCK_SIDE_P;
 
-        for (int dimension = 0; dimension < DIMENSIONS; dimension++) {
-            int currentFirstDimensionIter, currentSecondDimensionIter;  // The current iteration position in the x, y, and z dimensions, also known as i, j, and k.
-            int width, height; //The current iteration dimensions in the x, y, and z dimensions, also known as l, w, and h.
+        final ArrayList<int[]> materialMaskCols = new ArrayList<>();
+        materialMaskCols.add(0, new int[3 * BITS_PER_BLOCK_SIDE_P2]);
 
-            //We need to iterate over the other two dimensions.
-            final int firstDimensionIter = (dimension + 1) % DIMENSIONS; // The u and v dimensions are used to iterate over the other two dimensions.
-            final int secondDimensionIter = (dimension + 2) % DIMENSIONS;
-
-            final int[] dimensionalIterator = new int[]{0, 0, 0};
-            final int[] calculatedDimensionsOffset = new int[]{0, 0, 0}; //Dimension offset for the already calculated dimensions.
-
-            calculatedDimensionsOffset[dimension] = 1;
-            for (dimensionalIterator[dimension] = -1; dimensionalIterator[dimension] < sizePerDimension; ) {
-
-                //Compute mask
-                int maskIndex = 0;
-                for (dimensionalIterator[secondDimensionIter] = 0; dimensionalIterator[secondDimensionIter] < sizePerDimension; ++dimensionalIterator[secondDimensionIter]) {
-                    for (dimensionalIterator[firstDimensionIter] = 0; dimensionalIterator[firstDimensionIter] < sizePerDimension; ++dimensionalIterator[firstDimensionIter], ++maskIndex) {
-
-                        int currentMaterial = (0 <= dimensionalIterator[dimension] ? materialProcessor.getMaterialIndex(
-                                dimensionalIterator[0],
-                                dimensionalIterator[1],
-                                dimensionalIterator[2]) : 0);
-                        int neighborMaterial = (dimensionalIterator[dimension] < sizePerDimension - 1 ? materialProcessor.getMaterialIndex(
-                                dimensionalIterator[0] + calculatedDimensionsOffset[0],
-                                dimensionalIterator[1] + calculatedDimensionsOffset[1],
-                                dimensionalIterator[2] + calculatedDimensionsOffset[2]) : 0);
-
-                        boolean aIsTruthy = currentMaterial != 0;
-                        boolean bIsTruthy = neighborMaterial != 0;
-
-                        if (aIsTruthy == bIsTruthy) {
-                            mask[maskIndex] = 0;
-                        } else if (aIsTruthy) {
-                            mask[maskIndex] = currentMaterial;
-                        } else {
-                            mask[maskIndex] = -neighborMaterial;
-                        }
+        for (int x = 0; x < BITS_PER_BLOCK_SIDE_P; x++) {
+            for (int y = 0; y < BITS_PER_BLOCK_SIDE_P; y++) {
+                for (int z = 0; z < BITS_PER_BLOCK_SIDE_P; z++) {
+                    if (!materialData.getMaterial(x - 1, y - 1, z - 1).isSeeThrough()) {
+                        materialMaskCols.get(0)[x + (z * BITS_PER_BLOCK_SIDE_P)] |= (1 << y);
+                        materialMaskCols.get(0)[x + (y * BITS_PER_BLOCK_SIDE_P) + BITS_PER_BLOCK_SIDE_P2] |= (1 << z);
+                        materialMaskCols.get(0)[y + (z * BITS_PER_BLOCK_SIDE_P) + (BITS_PER_BLOCK_SIDE_P2 * 2)] |= (1 << x);
                     }
-                }
-
-                //Increment the computed position in the current dimension
-                dimensionalIterator[dimension]++;
-
-                //Compute the mesh
-                maskIndex = 0;
-                for (currentSecondDimensionIter = 0; currentSecondDimensionIter < sizePerDimension; ++currentSecondDimensionIter) {
-                    for(currentFirstDimensionIter = 0; currentFirstDimensionIter < sizePerDimension;) {
-                        int materialMask = mask[maskIndex];
-                        boolean isMaterialMaskTruthy = materialMask != 0;
-                        if (isMaterialMaskTruthy) {
-                            width = computeWidth(materialMask, mask, maskIndex, currentFirstDimensionIter, sizePerDimension);
-                            height = computeHeight(currentSecondDimensionIter, sizePerDimension, width, mask, maskIndex, materialMask);
-
-                            dimensionalIterator[firstDimensionIter] = currentFirstDimensionIter;
-                            dimensionalIterator[secondDimensionIter] = currentSecondDimensionIter;
-
-                            final GreedyMeshFace face = generateFace(materialMask, secondDimensionIter, height, firstDimensionIter, width, materialByIndex, dimensionalIterator, dimension, sizePerDimension);
-                            faces.add(face);
-
-                            clearMask(height, width, mask, maskIndex, sizePerDimension);
-
-                            currentFirstDimensionIter += width;
-                            maskIndex += width;
-                        } else {
-                            ++currentFirstDimensionIter;
-                            ++maskIndex;
+                    if (!RENDERTYPE_SOLID) {
+                        int materialIndex = materialProcessor.getMaterialIndex(x - 1, y - 1, z - 1);
+                        if (materialIndex != 0) {
+                            while (materialIndex >= materialMaskCols.size())
+                                materialMaskCols.add(new int[3 * BITS_PER_BLOCK_SIDE_P2]);
+                            materialMaskCols.get(materialIndex)[x + (z * BITS_PER_BLOCK_SIDE_P)] |= (1 << y);
+                            materialMaskCols.get(materialIndex)[x + (y * BITS_PER_BLOCK_SIDE_P) + BITS_PER_BLOCK_SIDE_P2] |= (1 << z);
+                            materialMaskCols.get(materialIndex)[y + (z * BITS_PER_BLOCK_SIDE_P) + (BITS_PER_BLOCK_SIDE_P2 * 2)] |= (1 << x);
                         }
                     }
                 }
             }
         }
 
+        List<HashMap<Integer, HashMap<Integer, int[]>>> faceData = new ArrayList<>(6);
+
+        if (RENDERTYPE_SOLID) {
+            int[] faceMaskCols = new int[6 * BITS_PER_BLOCK_SIDE_P2];
+
+            for (int axis = 0; axis < 3; axis++) {
+                for (int i = 0; i < BITS_PER_BLOCK_SIDE_P2; i++) {
+                    int col = materialMaskCols.get(0)[i + (BITS_PER_BLOCK_SIDE_P2 * axis)];
+                    faceMaskCols[i + (BITS_PER_BLOCK_SIDE_P2 * axis * 2)] = col & ~(col << 1);
+                    faceMaskCols[i + (BITS_PER_BLOCK_SIDE_P2 * ((axis * 2) + 1))] = col & ~(col >> 1);
+                }
+            }
+
+            for (int axis = 0; axis < 6; axis++) {
+                faceData.add(new HashMap<>());
+                for (int x = 0; x < BITS_PER_BLOCK_SIDE; x++) {
+                    for (int z = 0; z < BITS_PER_BLOCK_SIDE; z++) {
+                        int colIndex = 1 + x + ((z + 1) * BITS_PER_BLOCK_SIDE_P) + BITS_PER_BLOCK_SIDE_P2 * axis;
+
+                        int col = faceMaskCols[colIndex] >> 1;
+                        col &= ~(1 << BITS_PER_BLOCK_SIDE);
+
+                        while (col != 0) {
+                            int y = Integer.numberOfTrailingZeros(col);
+                            col &= col - 1;
+
+                            int bitMaterial = materialProcessor.getMaterialIndex(
+                                    Direction.values()[axis].getAxis().choose(y, x, x),
+                                    Direction.values()[axis].getAxis().choose(x, y, z),
+                                    Direction.values()[axis].getAxis().choose(z, z, y)
+                            );
+
+                            faceData.get(axis)
+                                    .computeIfAbsent(bitMaterial, k -> new HashMap<>())
+                                    .computeIfAbsent(y, k -> new int[BITS_PER_BLOCK_SIDE])[x] |= 1 << z;
+                        }
+                    }
+                }
+            }
+        }else {
+            final ArrayList<int[]> faceColMasks = new ArrayList<>();
+            materialMaskCols.forEach((material) -> faceColMasks.add(new int[6 * BITS_PER_BLOCK_SIDE_P2]));
+
+            for (int axis = 0; axis < 3; axis++) {
+                for (int i = 0; i < BITS_PER_BLOCK_SIDE_P2; i++) {
+                    int col = materialMaskCols.get(0)[i + (BITS_PER_BLOCK_SIDE_P2 * axis)];
+                    for (int material = 1; material < faceColMasks.size(); material++) {
+                        int materialCol = materialMaskCols.get(material)[i + (BITS_PER_BLOCK_SIDE_P2 * axis)];
+                        faceColMasks.get(material)[i + (BITS_PER_BLOCK_SIDE_P2 * axis * 2)] = materialCol & ~((materialCol | col) << 1);
+                        faceColMasks.get(material)[i + (BITS_PER_BLOCK_SIDE_P2 * ((axis * 2) + 1))] = materialCol & ~((materialCol | col) >> 1);
+                    }
+                }
+            }
+
+            for (int axis = 0; axis < 6; axis++) {
+                faceData.add(new HashMap<>());
+                for (int x = 0; x < BITS_PER_BLOCK_SIDE; x++) {
+                    for (int z = 0; z < BITS_PER_BLOCK_SIDE; z++) {
+                        int colIndex = 1 + x + ((z + 1) * BITS_PER_BLOCK_SIDE_P) + BITS_PER_BLOCK_SIDE_P2 * axis;
+                        for (int material = 1; material < faceColMasks.size(); material++) {
+                            int col = faceColMasks.get(material)[colIndex] >> 1;
+                            col &= ~(1 << BITS_PER_BLOCK_SIDE);
+
+                            while (col != 0) {
+                                int y = Integer.numberOfTrailingZeros(col);
+                                col &= col - 1;
+
+                                faceData.get(axis)
+                                        .computeIfAbsent(material, k -> new HashMap<>())
+                                        .computeIfAbsent(y, k -> new int[BITS_PER_BLOCK_SIDE])[x] |= 1 << z;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        for (int axis = 0; axis < faceData.size(); axis++) {
+            Direction faceDirection = Direction.values()[axis];
+            faceData.get(axis).forEach((material, axisFaces) -> axisFaces.forEach(
+                    (axisPos, plane) -> faces.addAll(greedyMeshBinaryPlane(plane, materials.get(material - 1), faceDirection, axisPos, BITS_PER_BLOCK_SIDE))
+            ));
+        }
         return faces.toArray(new GreedyMeshFace[0]);
     }
 
-    private static void clearMask(int height, int width, int[] mask, int maskIndex, int sizePerDimension) {
-        for (int x = 0; x < height; x++) {
-            for (int y = 0; y < width; y++) {
-                mask[maskIndex + y + x * sizePerDimension] = 0;
+    private static List<GreedyMeshFace> greedyMeshBinaryPlane(int[] data, IBlockInformation material, Direction direction, int axisPos, final int BITS_PER_BLOCK_SIDE) {
+        List<GreedyMeshFace> axisFaces = new ArrayList<>();
+        for (int row = 0; row < data.length; row++) {
+            int y = 0;
+            while (y < BITS_PER_BLOCK_SIDE) {
+                y += Integer.numberOfTrailingZeros(data[row] >> y);
+                if (y >= BITS_PER_BLOCK_SIDE) continue;
+                int height = Integer.numberOfTrailingZeros(~data[row] >> y);
+
+                int hAsMask = height < 32 ? (1 << height) - 1 : ~0;
+                int mask = hAsMask << y;
+
+                int width = 1;
+                while (row + width < BITS_PER_BLOCK_SIDE) {
+                    int nextRowH = (data[row + width] >> y) & hAsMask;
+                    if (nextRowH != hAsMask) break;
+                    data[row + width] = data[row + width] & ~mask;
+                    width++;
+                }
+                axisFaces.add(generateFace(material, row, y, height, width, axisPos, direction, BITS_PER_BLOCK_SIDE));
+                y += height;
             }
         }
+        return axisFaces;
     }
 
     @NotNull
-    private static GreedyMeshFace generateFace(int materialMask, int secondDimensionIter, int height, int firstDimensionIter, int width, Int2ObjectMap<IBlockInformation> materialByIndex, int[] dimensionalIterator, int dimension, float sizePerDimension) {
-        int[] deltaVertical = new int[]{0, 0, 0};
-        int[] deltaHorizontal = new int[]{0, 0, 0};
+    private static GreedyMeshFace generateFace(IBlockInformation material, int x, int y, int height, int width, int axisPos, Direction direction, final int BITS_PER_BLOCK_SIDE) {
+        final Vector3f lowerLeft = transformPos(new Vector3f(x, axisPos, y), direction).div(BITS_PER_BLOCK_SIDE);
+        final Vector3f upperLeft = transformPos(new Vector3f(x, axisPos, y + height), direction).div(BITS_PER_BLOCK_SIDE);
+        final Vector3f lowerRight = transformPos(new Vector3f(x + width, axisPos, y), direction).div(BITS_PER_BLOCK_SIDE);
+        final Vector3f upperRight = transformPos(new Vector3f(x + width, axisPos, y + height), direction).div(BITS_PER_BLOCK_SIDE);
 
-        final Direction.Axis axis = Direction.Axis.values()[dimension];
+        final boolean isEdge = axisPos == 0 || axisPos == BITS_PER_BLOCK_SIDE;
 
-        Direction.AxisDirection axisDirection = Direction.AxisDirection.POSITIVE;
-        if (materialMask > 0) {
-            deltaHorizontal[secondDimensionIter] = height;
-            deltaVertical[firstDimensionIter] = width;
-        } else {
-            axisDirection = Direction.AxisDirection.NEGATIVE;
-            materialMask = -materialMask;
-            deltaVertical[secondDimensionIter] = height;
-            deltaHorizontal[firstDimensionIter] = width;
-        }
-
-        final Direction normalDirection = Direction.fromAxisAndDirection(axis, axisDirection);
-
-        final IBlockInformation material = materialByIndex.get(materialMask);
-        final Vector3f lowerLeft = new Vector3f(dimensionalIterator[0], dimensionalIterator[1], dimensionalIterator[2]).div(sizePerDimension);
-        final Vector3f upperLeft = new Vector3f(dimensionalIterator[0] + deltaVertical[0], dimensionalIterator[1] + deltaVertical[1], dimensionalIterator[2] + deltaVertical[2]).div(sizePerDimension);
-        final Vector3f lowerRight = new Vector3f(dimensionalIterator[0] + deltaHorizontal[0], dimensionalIterator[1] + deltaHorizontal[1], dimensionalIterator[2] + deltaHorizontal[2]).div(sizePerDimension);
-        final Vector3f upperRight = new Vector3f(dimensionalIterator[0] + deltaVertical[0] + deltaHorizontal[0], dimensionalIterator[1] + deltaVertical[1] + deltaHorizontal[1], dimensionalIterator[2] + deltaVertical[2] + deltaHorizontal[2]).div(sizePerDimension);
-
-        final double axisValue = axis.choose(lowerLeft.x, lowerLeft.y, lowerLeft.z);
-
-        final boolean isEdge = axisValue == 0 || axisValue == sizePerDimension;
-
-        return new GreedyMeshFace(material, lowerLeft, upperLeft, lowerRight, upperRight, normalDirection, isEdge);
+        return new GreedyMeshFace(material, lowerLeft, upperLeft, lowerRight, upperRight, direction, isEdge);
     }
 
-    private static int computeHeight(int j, int sizePerDimension, int width, int[] mask, int maskIndex, int materialMask) {
-        int height;
-        int k;
-        boolean done = false;
-        for(height = 1; j + height < sizePerDimension; height++) {
-            for(k = 0; k < width; k++) {
-                if(mask[maskIndex + k + height * sizePerDimension] != materialMask) {
-                    done = true;
-                    break;
-                }
-            }
-            if(done) {
-                break;
-            }
+    private static Vector3f transformPos(Vector3f vector, Direction direction) {
+        Vector3f returnVector;
+        if (direction.getAxis().equals(Direction.Axis.X)) {
+            returnVector = new Vector3f(vector.y, vector.x, vector.z);
+        }else if (direction.getAxis().equals(Direction.Axis.Y)) {
+            returnVector = vector;
+        }else {
+            returnVector = new Vector3f(vector.x, vector.z, vector.y);
         }
-        return height;
+        if (direction.getAxisDirection().equals(Direction.AxisDirection.POSITIVE))
+            returnVector.add(direction.getNormal().getX(), direction.getNormal().getY(), direction.getNormal().getZ());
+        return returnVector;
     }
-
-    private static int computeWidth(int materialMask, int[] mask, int maskIndex, int i, int sizePerDimension) {
-        int width = 1;
-        while (i + width < sizePerDimension && materialMask == mask[maskIndex + width]) {
-            width++;
-        }
-        return width;
-    }
-
 }


### PR DESCRIPTION
Related to issue #1262

### Changes:
Adding `IBlockNeighborhood` to `ChiseledBlockBakedModel`'s Constructor and its private `generateFaces()` method.
Using `IBlockNeighborhood` when accessing `IBlockInformation` in `GreedyMeshBuilder.MaterialProvider` outside the current block.
Adding method `isSeeThrough()` to `IBlockInformation`
Adding `ChiselRenderType` as an argument to `GreedyMeshBuilder`'s `buildMesh()` method.
Replacing `GreedyMeshBuilder` with an extended binary greedy mesh builder.